### PR TITLE
Cherry-picking update from cp-docker-images

### DIFF
--- a/kafka-connect-base/Dockerfile
+++ b/kafka-connect-base/Dockerfile
@@ -62,6 +62,8 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
     && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
 
+ENV CONNECT_PLUGIN_PATH=/usr/share/java/,/usr/share/confluent-hub-components/
+
 VOLUME ["/etc/${COMPONENT}/jars", "/etc/${COMPONENT}/secrets"]
 
 COPY include/etc/confluent/docker /etc/confluent/docker

--- a/server-connect-base/Dockerfile
+++ b/server-connect-base/Dockerfile
@@ -63,6 +63,8 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
     && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
 
+ENV CONNECT_PLUGIN_PATH=/usr/share/java/,/usr/share/confluent-hub-components/
+
 VOLUME ["/etc/${COMPONENT}/jars", "/etc/${COMPONENT}/secrets"]
 
 COPY include/etc/confluent/docker /etc/confluent/docker


### PR DESCRIPTION
Original commit from cp-docker-images:
commit 3c5d67c17ee8aa6e65c2e6ebb3de1571e4eb5635
Author: Robin Moffatt <robin@confluent.io>
Date:   Thu Sep 12 20:01:16 2019 +0100

    Fix plugin path (#775)

    * Add plugin path env

    * Correct plugin path for replicator image

    * Move plugin_path environment var to base images
    only per @rhauch feedback