### PR TITLE
add back security-plugins to cp-server image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -66,6 +66,8 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && yum install -y confluent-server-${CONFLUENT_VERSION} \
     && echo "===> installing confluent-rebalancer ..." \
     && yum install -y confluent-rebalancer-${CONFLUENT_VERSION} \
+    && echo "===> installing confluent-security ..." \
+    && yum install -y confluent-security-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
     && yum clean all \
     && rm -rf /tmp/* \


### PR DESCRIPTION
It looks like in the process of setting up RH UBI images, we removed the installation of confluent-security which is needed for cp-server.  Adding it back.