### PR TITLE
REP-564 allow connect worker classpath to be overriden

### DIFF
--- a/kafka-connect-base/include/etc/confluent/docker/launch
+++ b/kafka-connect-base/include/etc/confluent/docker/launch
@@ -38,5 +38,7 @@ echo "===> Launching ${COMPONENT} ... "
 # Add external jars to the classpath
 # And this also makes sure that the CLASSPATH does not start with ":/etc/..."
 # because this causes the plugin scanner to scan the entire disk.
-export CLASSPATH="/etc/kafka-connect/jars/*"
+if [ -z "$CLASSPATH" ]; then
+    export CLASSPATH="/etc/kafka-connect/jars/*"
+fi
 exec connect-distributed /etc/"${COMPONENT}"/"${COMPONENT}".properties

--- a/server-connect-base/include/etc/confluent/docker/launch
+++ b/server-connect-base/include/etc/confluent/docker/launch
@@ -38,5 +38,7 @@ echo "===> Launching ${COMPONENT} ... "
 # Add external jars to the classpath
 # And this also makes sure that the CLASSPATH does not start with ":/etc/..."
 # because this causes the plugin scanner to scan the entire disk.
-export CLASSPATH="/etc/kafka-connect/jars/*"
+if [ -z "$CLASSPATH" ]; then
+    export CLASSPATH="/etc/kafka-connect/jars/*"
+fi
 exec connect-distributed /etc/"${COMPONENT}"/"${COMPONENT}".properties


### PR DESCRIPTION
This PR allows the connect worker classpath to be overridden. This is required for rest extension classes and avoids the workaround employed here:

https://github.com/confluentinc/examples/blob/master/multi-datacenter/docker-compose.yml#L120
