### PR TITLE
ST-2560: Adding support for building Debian and rhel images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,9 @@ dockerfile {
     nodeLabel = 'docker-oraclejdk8-compose-swarm'
     slackChannel = 'kafka-warn'
     upstreamProjects = []
-    dockerPullDeps = ['confluentinc/cp-base']
+    dockerPullDeps = ['confluentinc/cp-base-new']
     usePackages = true
     cron = '' // Disable the cron because this job requires parameters
+    cpImages = true
+    osTypes = ['deb8', 'rhel8']
 }

--- a/ce-kafka/Dockerfile.deb8
+++ b/ce-kafka/Dockerfile.deb8
@@ -17,13 +17,13 @@ ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG=latest
 ARG DOCKER_TAG
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-kafka-connect-base:${DOCKER_TAG}
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-kafka:${DOCKER_TAG}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
-
+ 
 # Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+LABEL MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
@@ -36,26 +36,30 @@ ARG CONFLUENT_PLATFORM_LABEL
 ARG CONFLUENT_DEB_VERSION
 ARG ALLOW_UNSIGNED
 
-ENV COMPONENT=kafka-connect
+ENV COMPONENT=kafka
 
+# primary
+EXPOSE 9092
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && apt-get update \
+    && apt-get -qq update \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
     && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
     && cat /etc/apt/sources.list \
-    && apt-get update \
     && apt-get install -y apt-transport-https \
-    && apt-get install -y procps \
-    && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
-    && apt-get install -y confluent-kafka-connect-jdbc=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-kafka-connect-elasticsearch=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-kafka-connect-storage-common=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-kafka-connect-s3=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-kafka-connect-jms=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    && echo "===> Cleaning up ..."  \
-    && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*
+    && apt-get -qq update \
+    && echo "===> installing confluent-rebalancer ..." \
+    && apt-get install -y confluent-rebalancer=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> clean up ..." \
+    && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
+    && echo "===> Setting up ${COMPONENT} dirs..." \
+    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\
+    && chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
+    && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper
 
-RUN echo "===> Installing GCS Sink Connector ..."
-RUN confluent-hub install confluentinc/kafka-connect-gcs:latest --no-prompt
+VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
+
+COPY include/etc/confluent/docker /etc/confluent/docker
+
+CMD ["/etc/confluent/docker/run"]

--- a/ce-kafka/Dockerfile.rhel8
+++ b/ce-kafka/Dockerfile.rhel8
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 ARG DOCKER_UPSTREAM_REGISTRY
-ARG DOCKER_UPSTREAM_TAG=latest
+ARG DOCKER_UPSTREAM_TAG=rhel8-latest
 ARG DOCKER_TAG
 
 FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-kafka:${DOCKER_TAG}
@@ -23,7 +23,7 @@ ARG PROJECT_VERSION
 ARG ARTIFACT_ID
  
 # Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+LABEL maintainer="partner-support@confluent.io"
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
@@ -33,8 +33,7 @@ LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
-ARG CONFLUENT_DEB_VERSION
-ARG ALLOW_UNSIGNED
+
 
 ENV COMPONENT=kafka
 
@@ -42,18 +41,13 @@ ENV COMPONENT=kafka
 EXPOSE 9092
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && apt-get -qq update \
-    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
-    && apt-get install -y apt-transport-https \
-    && apt-get -qq update \
+    && yum -q -y update \
     && echo "===> installing confluent-rebalancer ..." \
-    && apt-get install -y confluent-rebalancer=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    && echo "===> clean up ..." \
-    && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
-    && echo "===> Setting up ${COMPONENT} dirs..." \
+    && yum install -y confluent-rebalancer-${CONFLUENT_VERSION} \
+    && echo "===> clean up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/* \
+    && echo "===> Setting up ${COMPONENT} dirs  ..." \
     && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\
     && chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
     && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper

--- a/ce-kafka/include/etc/confluent/docker/kafka.properties.template
+++ b/ce-kafka/include/etc/confluent/docker/kafka.properties.template
@@ -10,16 +10,16 @@
                          'KAFKA_TOOLS_LOG4J_LOGLEVEL']
 -%}
 {% set kafka_props = env_to_props('KAFKA_', '', exclude=excluded_props) -%}
-{% for name, value in kafka_props.iteritems() -%}
+{% for name, value in kafka_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}
 
 {% set confluent_support_props = env_to_props('CONFLUENT_SUPPORT_', 'confluent.support.') -%}
-{% for name, value in confluent_support_props.iteritems() -%}
+{% for name, value in confluent_support_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}
 
 {% set confluent_metric_props = env_to_props('CONFLUENT_METRICS_', 'confluent.metrics.') -%}
-{% for name, value in confluent_metric_props.iteritems() -%}
+{% for name, value in confluent_metric_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/kafka-connect-base/Dockerfile.deb8
+++ b/kafka-connect-base/Dockerfile.deb8
@@ -23,7 +23,7 @@ ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 
 # Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+LABEL MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/kafka-connect-base/Dockerfile.rhel8
+++ b/kafka-connect-base/Dockerfile.rhel8
@@ -1,0 +1,71 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=rhel8-latest
+ARG DOCKER_TAG
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-kafka:${DOCKER_TAG}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+
+# Make sure you use an appropriate contact address.
+LABEL maintianer="partner-support@confluent.io"
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+
+
+ENV COMPONENT=kafka-connect
+
+# Default kafka-connect rest.port
+EXPOSE 8083
+
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && yum -q -y update \
+    && echo "===> Installing Schema Registry (for Avro jars) ..." \
+    && yum install -y confluent-schema-registry-${CONFLUENT_VERSION} \
+    && echo "===> Installing Controlcenter for monitoring interceptors ..."\
+    && yum install -y confluent-control-center-${CONFLUENT_VERSION} \
+    && echo "===> Installing Confluent Hub client ..."\
+    && yum install -y confluent-hub-client-${CONFLUENT_VERSION} \
+    && echo "===> Cleaning up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/* \
+    echo "===> Setting up ${COMPONENT} dirs ..." \
+    && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
+    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
+
+VOLUME ["/etc/${COMPONENT}/jars", "/etc/${COMPONENT}/secrets"]
+
+COPY include/etc/confluent/docker /etc/confluent/docker
+
+CMD ["/etc/confluent/docker/run"]
+
+# Polling period  : 5 seconds
+# Timeout period  :10 seconds (if the polling does not return within this time, treat as a failed poll)
+# Start-up period : 2 minutes (during which failures are not counted as failures)
+# Retry period    : 8 minutes (after which container is deemed unhealthy)
+# All settings can be overriden at run-time in Docker/Docker Compose. 
+HEALTHCHECK --start-period=120s --interval=5s --timeout=10s --retries=96 \
+    CMD /etc/confluent/docker/healthcheck.sh

--- a/kafka-connect-base/include/etc/confluent/docker/kafka-connect.properties.template
+++ b/kafka-connect-base/include/etc/confluent/docker/kafka-connect.properties.template
@@ -1,4 +1,4 @@
 {% set connect_props = env_to_props('CONNECT_', '') -%}
-{% for name, value in connect_props.iteritems() -%}
+{% for name, value in connect_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/kafka-connect-base/include/etc/confluent/docker/log4j.properties.template
+++ b/kafka-connect-base/include/etc/confluent/docker/log4j.properties.template
@@ -19,6 +19,6 @@ log4j.appender.stdout.layout.ConversionPattern ={{ env["CONNECT_LOG4J_APPENDER_S
 # default log levels
 {% set loggers = default_loggers %}
 {% endif %}
-{% for logger,loglevel in loggers.iteritems() %}
+{% for logger,loglevel in loggers.items() %}
 log4j.logger.{{logger}}={{loglevel}}
 {% endfor %}

--- a/kafka-connect/Dockerfile.deb8
+++ b/kafka-connect/Dockerfile.deb8
@@ -15,14 +15,15 @@
 
 ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG=latest
+ARG DOCKER_TAG
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base:${DOCKER_UPSTREAM_TAG}
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-kafka-connect-base:${DOCKER_TAG}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
- 
+
 # Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+LABEL MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
@@ -35,40 +36,26 @@ ARG CONFLUENT_PLATFORM_LABEL
 ARG CONFLUENT_DEB_VERSION
 ARG ALLOW_UNSIGNED
 
-# allow arg override of required env params
-ARG KAFKA_ZOOKEEPER_CONNECT
-ENV KAFKA_ZOOKEEPER_CONNECT=${KAFKA_ZOOKEEPER_CONNECT}
-ARG KAFKA_ADVERTISED_LISTENERS
-ENV KAFKA_ADVERTISED_LISTENERS=${KAFKA_ADVERTISED_LISTENERS}
+ENV COMPONENT=kafka-connect
 
-ENV COMPONENT=kafka
-
-# primary
-EXPOSE 9092
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && apt-get -qq update \
+    && apt-get update \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
     && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
     && cat /etc/apt/sources.list \
+    && apt-get update \
     && apt-get install -y apt-transport-https \
-    && apt-get -qq update \
-    && echo "===> installing ${COMPONENT}..." \
-    && apt-get install -y confluent-server=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    && echo "===> installing confluent-rebalancer ..." \
-    && apt-get install -y confluent-rebalancer=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    && echo "===> installing confluent-security ..." \
-    && apt-get install -y confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    && echo "===> clean up ..." \
-    && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
-    && echo "===> Setting up ${COMPONENT} dirs..." \
-    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\
-    && chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
-    && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper
+    && apt-get install -y procps \
+    && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
+    && apt-get install -y confluent-kafka-connect-jdbc=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    confluent-kafka-connect-elasticsearch=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    confluent-kafka-connect-storage-common=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    confluent-kafka-connect-s3=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    confluent-kafka-connect-jms=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> Cleaning up ..."  \
+    && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*
 
-VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
-
-COPY include/etc/confluent/docker /etc/confluent/docker
-
-CMD ["/etc/confluent/docker/run"]
+RUN echo "===> Installing GCS Sink Connector ..."
+RUN confluent-hub install confluentinc/kafka-connect-gcs:latest --no-prompt

--- a/kafka-connect/Dockerfile.rhel8
+++ b/kafka-connect/Dockerfile.rhel8
@@ -1,0 +1,55 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=rhel8-latest
+ARG DOCKER_TAG
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-kafka-connect-base:${DOCKER_TAG}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+
+# Make sure you use an appropriate contact address.
+LABEL maintainer="partner-support@confluent.io"
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+
+
+ENV COMPONENT=kafka-connect
+
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && yum -q -y update \
+    && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
+    && yum install -y \
+        confluent-kafka-connect-jdbc-${CONFLUENT_VERSION} \
+        confluent-kafka-connect-elasticsearch-${CONFLUENT_VERSION} \
+        confluent-kafka-connect-storage-common-${CONFLUENT_VERSION} \
+        confluent-kafka-connect-s3-${CONFLUENT_VERSION} \
+        confluent-kafka-connect-jms-${CONFLUENT_VERSION} \
+    && echo "===> Cleaning up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/*
+
+RUN echo "===> Installing GCS Sink Connector ..."
+RUN confluent-hub install confluentinc/kafka-connect-gcs:latest --no-prompt

--- a/kafka/Dockerfile.deb8
+++ b/kafka/Dockerfile.deb8
@@ -1,0 +1,72 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=latest
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+
+# Make sure you use an appropriate contact address.
+LABEL MAINTAINER partner-support@confluent.io
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+ARG CONFLUENT_DEB_VERSION
+ARG ALLOW_UNSIGNED
+ARG SCALA_VERSION
+
+# allow arg override of required env params
+ARG KAFKA_ZOOKEEPER_CONNECT
+ENV KAFKA_ZOOKEEPER_CONNECT=${KAFKA_ZOOKEEPER_CONNECT}
+ARG KAFKA_ADVERTISED_LISTENERS
+ENV KAFKA_ADVERTISED_LISTENERS=${KAFKA_ADVERTISED_LISTENERS}
+
+ENV COMPONENT=kafka
+
+# primary
+EXPOSE 9092
+
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && apt-get update \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
+    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
+    && cat /etc/apt/sources.list \
+    && apt-get install -y apt-transport-https \
+    && apt-get update \
+    && apt-get install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> clean up ..." \
+    && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
+    && echo "===> Setting up ${COMPONENT} dirs..." \
+    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\
+    && chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
+    && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper
+
+
+VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
+
+COPY include/etc/confluent/docker /etc/confluent/docker
+
+CMD ["/etc/confluent/docker/run"]

--- a/kafka/Dockerfile.rhel8
+++ b/kafka/Dockerfile.rhel8
@@ -14,15 +14,15 @@
 # limitations under the License.
 
 ARG DOCKER_UPSTREAM_REGISTRY
-ARG DOCKER_UPSTREAM_TAG=latest
+ARG DOCKER_UPSTREAM_TAG=rhel8-latest
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base:${DOCKER_UPSTREAM_TAG}
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 
 # Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+LABEL maintainer="partner-support@confluent.io"
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
@@ -32,8 +32,6 @@ LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
-ARG CONFLUENT_DEB_VERSION
-ARG ALLOW_UNSIGNED
 ARG SCALA_VERSION
 
 # allow arg override of required env params
@@ -49,20 +47,30 @@ EXPOSE 9092
 
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && apt-get update \
+    && yum -q -y update \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
-    && apt-get install -y apt-transport-https \
-    && apt-get update \
-    && apt-get install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    && echo "===> clean up ..." \
-    && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
-    && echo "===> Setting up ${COMPONENT} dirs..." \
-    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\
-    && chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
-    && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent.dist] \n\
+name=Confluent repository (dist) \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 \n\
+\n\
+[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && yum install -y confluent-kafka-${SCALA_VERSION}-${CONFLUENT_VERSION} \
+    && echo "===> clean up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/* \
+    \
+    && echo "===> Setting up ${COMPONENT} dirs" \
+    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
+    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets
 
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]

--- a/kafka/include/etc/confluent/docker/kafka.properties.template
+++ b/kafka/include/etc/confluent/docker/kafka.properties.template
@@ -10,11 +10,11 @@
                          'KAFKA_TOOLS_LOG4J_LOGLEVEL']
 -%}
 {% set kafka_props = env_to_props('KAFKA_', '', exclude=excluded_props) -%}
-{% for name, value in kafka_props.iteritems() -%}
+{% for name, value in kafka_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}
 
 {% set confluent_support_props = env_to_props('CONFLUENT_SUPPORT_', 'confluent.support.') -%}
-{% for name, value in confluent_support_props.iteritems() -%}
+{% for name, value in confluent_support_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/kafka/include/etc/confluent/docker/log4j.properties.template
+++ b/kafka/include/etc/confluent/docker/log4j.properties.template
@@ -21,6 +21,6 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 {% set loggers = parse_log4j_loggers(env['KAFKA_LOG4J_LOGGERS'], loggers) %}
 {% endif %}
 
-{% for logger,loglevel in loggers.iteritems() %}
+{% for logger,loglevel in loggers.items() %}
 log4j.logger.{{logger}}={{loglevel}}
 {% endfor %}

--- a/server-connect-base/Dockerfile.deb8
+++ b/server-connect-base/Dockerfile.deb8
@@ -1,0 +1,72 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=latest
+ARG DOCKER_TAG
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-server:${DOCKER_TAG}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ 
+# Make sure you use an appropriate contact address.
+LABEL MAINTAINER partner-support@confluent.io
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+ARG CONFLUENT_DEB_VERSION
+ARG ALLOW_UNSIGNED
+
+ENV COMPONENT=kafka-connect
+
+# Default kafka-connect rest.port
+EXPOSE 8083
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && apt-get -qq update \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
+    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
+    && cat /etc/apt/sources.list \
+    && apt-get install -y apt-transport-https \
+    && apt-get -qq update \
+    && echo "===> Installing Schema Registry (for Avro jars) ..." \
+    && apt-get install -y confluent-schema-registry=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> Installing Controlcenter for monitoring interceptors ..."\
+    && apt-get install -y confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> Installing Confluent security plugins ..." \
+    && apt-get install -y confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> Installing Confluent Hub client ..." \
+    && apt-get install -y confluent-hub-client=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> Cleaning up ..." \
+    && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
+    echo "===> Setting up ${COMPONENT} dirs ..." \
+    && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
+    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
+
+ENV CONNECT_PLUGIN_PATH=/usr/share/java/,/usr/share/confluent-hub-components/
+
+VOLUME ["/etc/${COMPONENT}/jars", "/etc/${COMPONENT}/secrets"]
+
+COPY include/etc/confluent/docker /etc/confluent/docker
+
+CMD ["/etc/confluent/docker/run"]

--- a/server-connect-base/Dockerfile.rhel8
+++ b/server-connect-base/Dockerfile.rhel8
@@ -1,0 +1,66 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=rhel8-latest
+ARG DOCKER_TAG
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-server:${DOCKER_TAG}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ 
+# Make sure you use an appropriate contact address.
+LABEL maintainer="partner-support@confluent.io"
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+
+
+ENV COMPONENT=kafka-connect
+
+# Default kafka-connect rest.port
+EXPOSE 8083
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && yum -q -y update \
+    && echo "===> Installing Schema Registry (for Avro jars) ..." \
+    && yum install -y confluent-schema-registry-${CONFLUENT_VERSION} \
+    && echo "===> Installing Controlcenter for monitoring interceptors ..."\
+    && yum install -y confluent-control-center-${CONFLUENT_VERSION} \
+    && echo "===> Installing Confluent security plugins ..." \
+    && yum install -y confluent-security-${CONFLUENT_VERSION} \
+    && echo "===> Installing Confluent Hub client ..." \
+    && yum install -y confluent-hub-client-${CONFLUENT_VERSION} \
+    && echo "===> Cleaning up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/* \
+    echo "===> Setting up ${COMPONENT} dirs ..." \
+    && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
+    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
+
+ENV CONNECT_PLUGIN_PATH=/usr/share/java/,/usr/share/confluent-hub-components/
+
+VOLUME ["/etc/${COMPONENT}/jars", "/etc/${COMPONENT}/secrets"]
+
+COPY include/etc/confluent/docker /etc/confluent/docker
+
+CMD ["/etc/confluent/docker/run"]

--- a/server-connect-base/include/etc/confluent/docker/kafka-connect.properties.template
+++ b/server-connect-base/include/etc/confluent/docker/kafka-connect.properties.template
@@ -1,4 +1,4 @@
 {% set connect_props = env_to_props('CONNECT_', '') -%}
-{% for name, value in connect_props.iteritems() -%}
+{% for name, value in connect_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/server-connect-base/include/etc/confluent/docker/log4j.properties.template
+++ b/server-connect-base/include/etc/confluent/docker/log4j.properties.template
@@ -18,6 +18,6 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 # default log levels
 {% set loggers = default_loggers %}
 {% endif %}
-{% for logger,loglevel in loggers.iteritems() %}
+{% for logger,loglevel in loggers.items() %}
 log4j.logger.{{logger}}={{loglevel}}
 {% endfor %}

--- a/server-connect/Dockerfile.deb8
+++ b/server-connect/Dockerfile.deb8
@@ -23,7 +23,7 @@ ARG PROJECT_VERSION
 ARG ARTIFACT_ID
  
 # Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+LABEL MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/server-connect/Dockerfile.rhel8
+++ b/server-connect/Dockerfile.rhel8
@@ -1,0 +1,54 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=rhel8-latest
+ARG DOCKER_TAG
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-server-connect-base:${DOCKER_TAG}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ 
+# Make sure you use an appropriate contact address.
+LABEL maintainer="partner-support@confluent.io"
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+
+
+ENV COMPONENT=kafka-connect
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && yum -q -y update \
+    && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
+    && yum install -y \
+        confluent-kafka-connect-jdbc-${CONFLUENT_VERSION} \
+        confluent-kafka-connect-elasticsearch-${CONFLUENT_VERSION} \
+        confluent-kafka-connect-storage-common-${CONFLUENT_VERSION} \
+        confluent-kafka-connect-s3-${CONFLUENT_VERSION} \
+        confluent-kafka-connect-jms-${CONFLUENT_VERSION} \
+    && echo "===> Cleaning up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/*
+
+RUN echo "===> Installing GCS Sink Connector ..."
+RUN confluent-hub install confluentinc/kafka-connect-gcs:latest --no-prompt

--- a/server/Dockerfile.deb8
+++ b/server/Dockerfile.deb8
@@ -15,15 +15,14 @@
 
 ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG=latest
-ARG DOCKER_TAG
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-server:${DOCKER_TAG}
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
  
 # Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+LABEL MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
@@ -36,10 +35,16 @@ ARG CONFLUENT_PLATFORM_LABEL
 ARG CONFLUENT_DEB_VERSION
 ARG ALLOW_UNSIGNED
 
-ENV COMPONENT=kafka-connect
+# allow arg override of required env params
+ARG KAFKA_ZOOKEEPER_CONNECT
+ENV KAFKA_ZOOKEEPER_CONNECT=${KAFKA_ZOOKEEPER_CONNECT}
+ARG KAFKA_ADVERTISED_LISTENERS
+ENV KAFKA_ADVERTISED_LISTENERS=${KAFKA_ADVERTISED_LISTENERS}
 
-# Default kafka-connect rest.port
-EXPOSE 8083
+ENV COMPONENT=kafka
+
+# primary
+EXPOSE 9092
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get -qq update \
@@ -49,23 +54,20 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && cat /etc/apt/sources.list \
     && apt-get install -y apt-transport-https \
     && apt-get -qq update \
-    && echo "===> Installing Schema Registry (for Avro jars) ..." \
-    && apt-get install -y confluent-schema-registry=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    && echo "===> Installing Controlcenter for monitoring interceptors ..."\
-    && apt-get install -y confluent-control-center=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    && echo "===> Installing Confluent security plugins ..." \
+    && echo "===> installing ${COMPONENT}..." \
+    && apt-get install -y confluent-server=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> installing confluent-rebalancer ..." \
+    && apt-get install -y confluent-rebalancer=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && echo "===> installing confluent-security ..." \
     && apt-get install -y confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    && echo "===> Installing Confluent Hub client ..." \
-    && apt-get install -y confluent-hub-client=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    && echo "===> Cleaning up ..." \
+    && echo "===> clean up ..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
-    echo "===> Setting up ${COMPONENT} dirs ..." \
-    && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
-    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
+    && echo "===> Setting up ${COMPONENT} dirs..." \
+    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\
+    && chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
+    && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper
 
-ENV CONNECT_PLUGIN_PATH=/usr/share/java/,/usr/share/confluent-hub-components/
-
-VOLUME ["/etc/${COMPONENT}/jars", "/etc/${COMPONENT}/secrets"]
+VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
 
 COPY include/etc/confluent/docker /etc/confluent/docker
 

--- a/server/Dockerfile.rhel8
+++ b/server/Dockerfile.rhel8
@@ -1,0 +1,83 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=rhel8-latest
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ 
+# Make sure you use an appropriate contact address.
+LABEL maintainer="partner-support@confluent.io"
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+
+
+# allow arg override of required env params
+ARG KAFKA_ZOOKEEPER_CONNECT
+ENV KAFKA_ZOOKEEPER_CONNECT=${KAFKA_ZOOKEEPER_CONNECT}
+ARG KAFKA_ADVERTISED_LISTENERS
+ENV KAFKA_ADVERTISED_LISTENERS=${KAFKA_ADVERTISED_LISTENERS}
+
+ENV COMPONENT=kafka
+
+# primary
+EXPOSE 9092
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && yum -q -y update \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent.dist] \n\
+name=Confluent repository (dist) \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 \n\
+\n\
+[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && echo "===> installing ${COMPONENT}..." \
+    && yum install -y confluent-server-${CONFLUENT_VERSION} \
+    && echo "===> installing confluent-rebalancer ..." \
+    && yum install -y confluent-rebalancer-${CONFLUENT_VERSION} \
+    && echo "===> installing confluent-security ..." \
+    && yum install -y confluent-security-${CONFLUENT_VERSION} \
+    && echo "===> clean up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/* \
+    && echo "===> Setting up ${COMPONENT} dirs" \
+    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
+    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
+    && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper
+
+VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
+
+COPY include/etc/confluent/docker /etc/confluent/docker
+
+CMD ["/etc/confluent/docker/run"]

--- a/server/include/etc/confluent/docker/kafka.properties.template
+++ b/server/include/etc/confluent/docker/kafka.properties.template
@@ -10,16 +10,16 @@
                          'KAFKA_TOOLS_LOG4J_LOGLEVEL']
 -%}
 {% set kafka_props = env_to_props('KAFKA_', '', exclude=excluded_props) -%}
-{% for name, value in kafka_props.iteritems() -%}
+{% for name, value in kafka_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}
 
 {% set confluent_support_props = env_to_props('CONFLUENT_SUPPORT_', 'confluent.support.') -%}
-{% for name, value in confluent_support_props.iteritems() -%}
+{% for name, value in confluent_support_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}
 
 {% set confluent_metric_props = env_to_props('CONFLUENT_METRICS_', 'confluent.metrics.') -%}
-{% for name, value in confluent_metric_props.iteritems() -%}
+{% for name, value in confluent_metric_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/server/include/etc/confluent/docker/log4j.properties.template
+++ b/server/include/etc/confluent/docker/log4j.properties.template
@@ -21,6 +21,6 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 {% set loggers = parse_log4j_loggers(env['KAFKA_LOG4J_LOGGERS'], loggers) %}
 {% endif %}
 
-{% for logger,loglevel in loggers.iteritems() %}
+{% for logger,loglevel in loggers.items() %}
 log4j.logger.{{logger}}={{loglevel}}
 {% endfor %}

--- a/zookeeper/Dockerfile.deb8
+++ b/zookeeper/Dockerfile.deb8
@@ -16,13 +16,13 @@
 ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG=latest
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base:${DOCKER_UPSTREAM_TAG}
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 
 # Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+LABEL MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/zookeeper/Dockerfile.rhel8
+++ b/zookeeper/Dockerfile.rhel8
@@ -1,0 +1,71 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=rhel8-latest
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+
+# Make sure you use an appropriate contact address.
+LABEL maintainer="partner-support@confluent.io"
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+ARG SCALA_VERSION
+
+EXPOSE 2181 2888 3888
+
+ENV COMPONENT=zookeeper
+
+RUN echo "===> Installing ${COMPONENT}..." \
+    && yum -q -y update \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent.dist] \n\
+name=Confluent repository (dist) \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 \n\
+\n\
+[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && yum install -y confluent-kafka-${SCALA_VERSION}-${CONFLUENT_VERSION} \
+    && echo "===> clean up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/* \
+    && echo "===> Setting up ${COMPONENT} dirs" \
+    && mkdir -p /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \
+    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \
+    && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper
+
+VOLUME ["/var/lib/${COMPONENT}/data", "/var/lib/${COMPONENT}/log", "/etc/${COMPONENT}/secrets"]
+
+COPY include/etc/confluent/docker /etc/confluent/docker
+
+CMD ["/etc/confluent/docker/run"]

--- a/zookeeper/include/etc/confluent/docker/log4j.properties.template
+++ b/zookeeper/include/etc/confluent/docker/log4j.properties.template
@@ -7,7 +7,7 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 
 {% if env['ZOOKEEPER_LOG4J_LOGGERS'] %}
 {% set loggers = parse_log4j_loggers(env['ZOOKEEPER_LOG4J_LOGGERS']) %}
-{% for logger,loglevel in loggers.iteritems() %}
+{% for logger,loglevel in loggers.items() %}
 log4j.logger.{{logger}}={{loglevel}}, stdout
 {% endfor %}
 {% endif %}

--- a/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
+++ b/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
@@ -29,7 +29,7 @@ dataLogDir=/var/lib/zookeeper/log
   'ZOOKEEPER_QUORUM_LISTEN_ON_ALL_IPS': 'quorumListenOnAllIPs'
  } -%}
 
-{% for k, property in other_props.iteritems() -%}
+{% for k, property in other_props.items() -%}
 {% if env.get(k) != None -%}
 {{property}}={{env[k]}}
 {% endif -%}


### PR DESCRIPTION
Renamed the Dockerfile to Dockerfile.deb8, and added Dockerfile.rhel8. The image now uses cp-base-new because we are building multiple versions of the new base image, one of which is the existing deb8 version which will still get used here. So to clarify, this will not upgrade the debian image to use a new version of debian even though we are using cp-base-new.

I have tested the debian image locally and it worked with cp-demo. Testing of the rhel image with cp-demo is still on going.