### PR TITLE
ST-2811: Adding support for running as appuser in rhel image

### DIFF
--- a/ce-kafka/Dockerfile.rhel8
+++ b/ce-kafka/Dockerfile.rhel8
@@ -34,11 +34,12 @@ ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
 
-
 ENV COMPONENT=kafka
 
 # primary
 EXPOSE 9092
+
+USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && yum -q -y update \
@@ -48,12 +49,14 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && yum clean all \
     && rm -rf /tmp/* \
     && echo "===> Setting up ${COMPONENT} dirs  ..." \
-    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\
+    && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
     && chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
-    && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper
+    && chown -R appuser:appuser /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper /etc/${COMPONENT}
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
 
-COPY include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+
+USER appuser
 
 CMD ["/etc/confluent/docker/run"]

--- a/kafka-connect-base/Dockerfile.rhel8
+++ b/kafka-connect-base/Dockerfile.rhel8
@@ -34,31 +34,34 @@ ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
 
-
 ENV COMPONENT=kafka-connect
 
 # Default kafka-connect rest.port
 EXPOSE 8083
 
+USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && yum -q -y update \
     && echo "===> Installing Schema Registry (for Avro jars) ..." \
     && yum install -y confluent-schema-registry-${CONFLUENT_VERSION} \
-    && echo "===> Installing Controlcenter for monitoring interceptors ..."\
+    && echo "===> Installing Controlcenter for monitoring interceptors ..." \
     && yum install -y confluent-control-center-${CONFLUENT_VERSION} \
     && echo "===> Installing Confluent Hub client ..."\
     && yum install -y confluent-hub-client-${CONFLUENT_VERSION} \
-    && echo "===> Cleaning up ..."  \
+    && echo "===> Cleaning up ..." \
     && yum clean all \
     && rm -rf /tmp/* \
-    echo "===> Setting up ${COMPONENT} dirs ..." \
+    && echo "===> Setting up ${COMPONENT} dirs ..." \
     && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
+    && chown appuser:appuser -R /etc/${COMPONENT} \
     && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
 
 VOLUME ["/etc/${COMPONENT}/jars", "/etc/${COMPONENT}/secrets"]
 
-COPY include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+
+USER appuser
 
 CMD ["/etc/confluent/docker/run"]
 

--- a/kafka-connect/Dockerfile.rhel8
+++ b/kafka-connect/Dockerfile.rhel8
@@ -34,9 +34,9 @@ ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
 
-
 ENV COMPONENT=kafka-connect
 
+USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && yum -q -y update \
@@ -47,9 +47,11 @@ RUN echo "===> Installing ${COMPONENT}..." \
         confluent-kafka-connect-storage-common-${CONFLUENT_VERSION} \
         confluent-kafka-connect-s3-${CONFLUENT_VERSION} \
         confluent-kafka-connect-jms-${CONFLUENT_VERSION} \
-    && echo "===> Cleaning up ..."  \
+    && echo "===> Cleaning up ..." \
     && yum clean all \
     && rm -rf /tmp/*
 
-RUN echo "===> Installing GCS Sink Connector ..."
-RUN confluent-hub install confluentinc/kafka-connect-gcs:latest --no-prompt
+RUN echo "===> Installing GCS Sink Connector ..." \
+    && confluent-hub install confluentinc/kafka-connect-gcs:latest --no-prompt
+
+USER appuser

--- a/kafka/Dockerfile.rhel8
+++ b/kafka/Dockerfile.rhel8
@@ -45,6 +45,7 @@ ENV COMPONENT=kafka
 # primary
 EXPOSE 9092
 
+USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && yum -q -y update \
@@ -67,14 +68,15 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && echo "===> clean up ..."  \
     && yum clean all \
     && rm -rf /tmp/* \
-    \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
+    && chown appuser:appuser -R /var/lib/${COMPONENT} /etc/${COMPONENT} \
     && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets
-
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
 
-COPY include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+
+USER appuser
 
 CMD ["/etc/confluent/docker/run"]

--- a/server-connect-base/Dockerfile.rhel8
+++ b/server-connect-base/Dockerfile.rhel8
@@ -34,11 +34,12 @@ ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
 
-
 ENV COMPONENT=kafka-connect
 
 # Default kafka-connect rest.port
 EXPOSE 8083
+
+USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && yum -q -y update \
@@ -53,14 +54,17 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && echo "===> Cleaning up ..."  \
     && yum clean all \
     && rm -rf /tmp/* \
-    echo "===> Setting up ${COMPONENT} dirs ..." \
+    && echo "===> Setting up ${COMPONENT} dirs ..." \
     && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
+    && chown appuser:appuser -R /etc/${COMPONENT} \
     && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
 
 ENV CONNECT_PLUGIN_PATH=/usr/share/java/,/usr/share/confluent-hub-components/
 
 VOLUME ["/etc/${COMPONENT}/jars", "/etc/${COMPONENT}/secrets"]
 
-COPY include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+
+USER appuser
 
 CMD ["/etc/confluent/docker/run"]

--- a/server-connect/Dockerfile.rhel8
+++ b/server-connect/Dockerfile.rhel8
@@ -34,8 +34,9 @@ ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
 
-
 ENV COMPONENT=kafka-connect
+
+USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && yum -q -y update \
@@ -46,9 +47,11 @@ RUN echo "===> Installing ${COMPONENT}..." \
         confluent-kafka-connect-storage-common-${CONFLUENT_VERSION} \
         confluent-kafka-connect-s3-${CONFLUENT_VERSION} \
         confluent-kafka-connect-jms-${CONFLUENT_VERSION} \
-    && echo "===> Cleaning up ..."  \
+    && echo "===> Cleaning up ..." \
     && yum clean all \
     && rm -rf /tmp/*
 
-RUN echo "===> Installing GCS Sink Connector ..."
-RUN confluent-hub install confluentinc/kafka-connect-gcs:latest --no-prompt
+RUN echo "===> Installing GCS Sink Connector ..." \
+    && confluent-hub install confluentinc/kafka-connect-gcs:latest --no-prompt
+
+USER appuser

--- a/server/Dockerfile.rhel8
+++ b/server/Dockerfile.rhel8
@@ -33,7 +33,6 @@ ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
 
-
 # allow arg override of required env params
 ARG KAFKA_ZOOKEEPER_CONNECT
 ENV KAFKA_ZOOKEEPER_CONNECT=${KAFKA_ZOOKEEPER_CONNECT}
@@ -44,6 +43,8 @@ ENV COMPONENT=kafka
 
 # primary
 EXPOSE 9092
+
+USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && yum -q -y update \
@@ -74,10 +75,12 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
     && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
-    && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper
+    && chown -R appuser:appuser /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper /etc/${COMPONENT}/secrets
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
 
-COPY include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+
+USER appuser
 
 CMD ["/etc/confluent/docker/run"]

--- a/zookeeper/Dockerfile.rhel8
+++ b/zookeeper/Dockerfile.rhel8
@@ -38,6 +38,8 @@ EXPOSE 2181 2888 3888
 
 ENV COMPONENT=zookeeper
 
+USER root
+
 RUN echo "===> Installing ${COMPONENT}..." \
     && yum -q -y update \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
@@ -62,10 +64,12 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \
     && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \
-    && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper
+    && chown -R appuser:appuser /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper /etc/${COMPONENT}/secrets
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/var/lib/${COMPONENT}/log", "/etc/${COMPONENT}/secrets"]
 
-COPY include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+
+USER appuser
 
 CMD ["/etc/confluent/docker/run"]


### PR DESCRIPTION
The base image now has a user account "appuser" and this change will make the service run as that user instead of root.

The PR build for this will not succeed until the new version of the base image is published with the appuser.

I tested these changes by building the image and running cp-demo.