### PR TITLE
ST-2811: Create usr/logs folder in rhel image

### DIFF
--- a/server-connect-base/Dockerfile.rhel8
+++ b/server-connect-base/Dockerfile.rhel8
@@ -55,8 +55,8 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && yum clean all \
     && rm -rf /tmp/* \
     && echo "===> Setting up ${COMPONENT} dirs ..." \
-    && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
-    && chown appuser:appuser -R /etc/${COMPONENT} \
+    && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars /usr/logs \
+    && chown appuser:appuser -R /etc/${COMPONENT} /usr/logs \
     && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
 
 ENV CONNECT_PLUGIN_PATH=/usr/share/java/,/usr/share/confluent-hub-components/


### PR DESCRIPTION
When running cp-demo using the rhel images I get an error because the /usr/logs folder does not exist and can not be created because we are no longer running as the root user. This will create the /usr/logs directory and make the appuser the owner. I tested this by creating the image locally and running cp-demo.