### PR TITLE
[ST-3300] modify properties and ensure files for ZK TLS support

### DIFF
--- a/kafka/include/etc/confluent/docker/ensure
+++ b/kafka/include/etc/confluent/docker/ensure
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016 Confluent Inc.
+# Copyright 2020 Confluent Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,5 +20,10 @@ export KAFKA_DATA_DIRS=${KAFKA_DATA_DIRS:-"/var/lib/kafka/data"}
 echo "===> Check if $KAFKA_DATA_DIRS is writable ..."
 dub path "$KAFKA_DATA_DIRS" writable
 
-echo "===> Check if Zookeeper is healthy ..."
-cub zk-ready "$KAFKA_ZOOKEEPER_CONNECT" "${KAFKA_CUB_ZK_TIMEOUT:-40}"
+if [[ $KAFKA_ZOOKEEPER_SSL_CLIENT_ENABLE == "true" ]]
+then
+    echo "===> Skipping Zookeeper health check for SSL connections..."
+else
+    echo "===> Check if Zookeeper is healthy ..."
+    cub zk-ready "$KAFKA_ZOOKEEPER_CONNECT" "${KAFKA_CUB_ZK_TIMEOUT:-40}"
+fi

--- a/kafka/include/etc/confluent/docker/kafka.properties.template
+++ b/kafka/include/etc/confluent/docker/kafka.properties.template
@@ -7,11 +7,24 @@
                          'KAFKA_GC_LOG_OPTS',
                          'KAFKA_LOG4J_ROOT_LOGLEVEL',
                          'KAFKA_LOG4J_LOGGERS',
-                         'KAFKA_TOOLS_LOG4J_LOGLEVEL']
+                         'KAFKA_TOOLS_LOG4J_LOGLEVEL',
+                         'KAFKA_ZOOKEEPER_CLIENT_CNXN_SOCKET']
 -%}
+
+{# properties that don't fit the standard format #}
+{% set other_props = {
+  'KAFKA_ZOOKEEPER_CLIENT_CNXN_SOCKET' : 'zookeeper.clientCnxnSocket'
+ } -%}
+
 {% set kafka_props = env_to_props('KAFKA_', '', exclude=excluded_props) -%}
 {% for name, value in kafka_props.items() -%}
 {{name}}={{value}}
+{% endfor -%}
+
+{% for k, property in other_props.items() -%}
+{% if env.get(k) != None -%}
+{{property}}={{env[k]}}
+{% endif -%}
 {% endfor -%}
 
 {% set confluent_support_props = env_to_props('CONFLUENT_SUPPORT_', 'confluent.support.') -%}

--- a/server/include/etc/confluent/docker/ensure
+++ b/server/include/etc/confluent/docker/ensure
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2019 Confluent Inc.
+# Copyright 2020 Confluent Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,5 +20,10 @@ export KAFKA_DATA_DIRS=${KAFKA_DATA_DIRS:-"/var/lib/kafka/data"}
 echo "===> Check if $KAFKA_DATA_DIRS is writable ..."
 dub path "$KAFKA_DATA_DIRS" writable
 
-echo "===> Check if Zookeeper is healthy ..."
-cub zk-ready "$KAFKA_ZOOKEEPER_CONNECT" "${KAFKA_CUB_ZK_TIMEOUT:-40}"
+if [[ $KAFKA_ZOOKEEPER_SSL_CLIENT_ENABLE == "true" ]]
+then
+    echo "===> Skipping Zookeeper health check for SSL connections..."
+else
+    echo "===> Check if Zookeeper is healthy ..."
+    cub zk-ready "$KAFKA_ZOOKEEPER_CONNECT" "${KAFKA_CUB_ZK_TIMEOUT:-40}"
+fi

--- a/server/include/etc/confluent/docker/kafka.properties.template
+++ b/server/include/etc/confluent/docker/kafka.properties.template
@@ -7,12 +7,25 @@
                          'KAFKA_GC_LOG_OPTS',
                          'KAFKA_LOG4J_ROOT_LOGLEVEL',
                          'KAFKA_LOG4J_LOGGERS',
-                         'KAFKA_TOOLS_LOG4J_LOGLEVEL']
+                         'KAFKA_TOOLS_LOG4J_LOGLEVEL',
+                         'KAFKA_ZOOKEEPER_CLIENT_CNXN_SOCKET']
 -%}
+
+{# properties that don't fit the standard format #}
+{% set other_props = {
+  'KAFKA_ZOOKEEPER_CLIENT_CNXN_SOCKET' : 'zookeeper.clientCnxnSocket'
+ } -%}
+
 {% set kafka_props = env_to_props('KAFKA_', '', exclude=excluded_props) -%}
 {% for name, value in kafka_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}
+
+{% for k, property in other_props.items() -%}
+{% if env.get(k) != None -%}
+{{property}}={{env[k]}}
+{% endif -%}
+{% endfor -%}-%}
 
 {% set confluent_support_props = env_to_props('CONFLUENT_SUPPORT_', 'confluent.support.') -%}
 {% for name, value in confluent_support_props.items() -%}

--- a/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
+++ b/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
@@ -1,10 +1,10 @@
 
-clientPort={{ env['ZOOKEEPER_CLIENT_PORT'] }}
 dataDir=/var/lib/zookeeper/data
 dataLogDir=/var/lib/zookeeper/log
 
 {# optional properties #}
 {% set other_props = {
+  'ZOOKEEPER_CLIENT_PORT' : 'clientPort',
   'ZOOKEEPER_TICK_TIME': 'tickTime',
   'ZOOKEEPER_GLOBAL_OUTSTANDING_LIMIT' : 'globalOutstandingLimit',
   'ZOOKEEPER_PRE_ALLOC_SIZE': 'preAllocSize',
@@ -26,13 +26,55 @@ dataLogDir=/var/lib/zookeeper/log
   'ZOOKEEPER_FORCE_SYNC': 'forceSync',
   'ZOOKEEPER_JUTE_MAX_BUFFER': 'jute.maxbuffer',
   'ZOOKEEPER_SKIP_ACL': 'skipACL',
-  'ZOOKEEPER_QUORUM_LISTEN_ON_ALL_IPS': 'quorumListenOnAllIPs'
+  'ZOOKEEPER_QUORUM_LISTEN_ON_ALL_IPS': 'quorumListenOnAllIPs',
+  'ZOOKEEPER_CLIENT_CNXN_SOCKET' : 'clientCnxnSocket',
+  'ZOOKEEPER_SECURE_CLIENT_PORT' : 'secureClientPort',
+  'ZOOKEEPER_SERVER_CNXN_SOCKET' : 'serverCnxnSocket',
+  'ZOOKEEPER_X509_AUTHENTICATION_PROVIDER_SUPER_USER' : 'X509AuthenticationProvider.superUser',
+  'ZOOKEEPER_SSL_AUTH_PROVIDER' : 'ssl.authProvider',
+  'ZOOKEEPER_SSL_CLIENT_AUTH' : 'ssl.clientAuth',
+  'ZOOKEEPER_SSL_KEYSTORE_LOCATION' : 'ssl.keyStore.location',
+  'ZOOKEEPER_SSL_KEYSTORE_PASSWORD' : 'ssl.keyStore.password',
+  'ZOOKEEPER_SSL_KEYSTORE_TYPE' : 'ssl.keyStore.type',
+  'ZOOKEEPER_SSL_TRUSTSTORE_LOCATION' : 'ssl.trustStore.location',
+  'ZOOKEEPER_SSL_TRUSTSTORE_PASSWORD' : 'ssl.trustStore.password',
+  'ZOOKEEPER_SSL_TRUSTSTORE_TYPE' : 'ssl.trustStore.type',
+  'ZOOKEEPER_SSL_ENABLED_PROTOCOLS' : 'ssl.enabledProtocols',
+  'ZOOKEEPER_SSL_CIPHER_SUITES' : 'ssl.ciphersuites',
+  'ZOOKEEPER_SSL_HOSTNAME_VERIFICATION' : 'ssl.hostnameVerification',
+  'ZOOKEEPER_SSL_HANDSHAKE_DETECTION_TIMEOUT_MILLIS' : 'ssl.handshakeDetectionTimeoutMillis',
+  'ZOOKEEPER_SSL_QUORUM' : 'sslQuorum',
+  'ZOOKEEPER_SSL_QUORUM_CLIENT_AUTH' : 'ssl.quorum.clientAuth',
+  'ZOOKEEPER_SSL_QUORUM_KEYSTORE_LOCATION' : 'ssl.quorum.keyStore.location',
+  'ZOOKEEPER_SSL_QUORUM_KEYSTORE_PASSWORD' : 'ssl.quorum.keyStore.password',
+  'ZOOKEEPER_SSL_QUORUM_KEYSTORE_TYPE' : 'ssl.quorum.keyStore.type',
+  'ZOOKEEPER_SSL_QUORUM_TRUSTSTORE_LOCATION' : 'ssl.quorum.trustStore.location',
+  'ZOOKEEPER_SSL_QUORUM_TRUSTSTORE_PASSWORD' : 'ssl.quorum.trustStore.password',
+  'ZOOKEEPER_SSL_QUORUM_TRUSTSTORE_TYPE' : 'ssl.quorum.trustStore.type',
+  'ZOOKEEPER_SSL_QUORUM_ENABLED_PROTOCOLS' : 'ssl.quorum.enabledProtocols',
+  'ZOOKEEPER_SSL_QUORUM_CIPHER_SUITES' : 'ssl.quorum.ciphersuites',
+  'ZOOKEEPER_SSL_QUORUM_HOSTNAME_VERIFICATION' : 'ssl.quorum.hostnameVerification',
+  'ZOOKEEPER_SSL_QUORUM_HANDSHAKE_DETECTION_TIMEOUT_MILLIS' : 'ssl.quorum.handshakeDetectionTimeoutMillis',
+  'ZOOKEEPER_SERVER_CNXN_FACTORY' : 'serverCnxnFactory',
+  'ZOOKEEPER_AUTH_PROVIDER_X509' : 'authProvider.x509',
+  'ZOOKEEPER_AUTH_PROVIDER_SASL' : 'authProvider.sasl',
+  'ZOOKEEPER_CLIENT_PORT_UNIFICATION' : 'client.portUnification',
+  'ZOOKEEPER_ADMIN_ENABLE_SERVER' : 'admin.enableServer',
+  'ZOOKEEPER_ADMIN_SERVER_ADDRESS' : 'admin.serverAddress',
+  'ZOOKEEPER_ADMIN_SERVER_PORT' : 'admin.serverPort',
+  'ZOOKEEPER_ADMIN_IDLE_TIMEOUT' : 'admin.idleTimeout',
+  'ZOOKEEPER_ADMIN_COMMAND_URL' : 'admin.commandURL'
  } -%}
 
 {% for k, property in other_props.items() -%}
 {% if env.get(k) != None -%}
 {{property}}={{env[k]}}
 {% endif -%}
+{% endfor -%}
+
+{% set zookeeper_props = env_to_props('ZOOKEEPER_', '', exclude=other_props) -%}
+{% for name, value in zookeeper_props.items() -%}
+{{name}}={{value}}
 {% endfor -%}
 
 {% if env['ZOOKEEPER_SERVERS'] %}


### PR DESCRIPTION
In order to support New TLS support in ZK, we need:

1) Add many properties to the ZK template for docker environment variables related mostly to SSL configs
2) modify kafka and server properties for one specific property (zookeeper.clientCnxnSocket) which doesn't follow the normal pattern for converting ENV variables
3) modify kafka and server ensure to skip ZK_READY check for SSL as the connectivity check doesn't support TLS. This can be removed once that support is added in the future.  