### PR TITLE
ST-3599: Remove show_env function because it exposes secrets

### DIFF
--- a/kafka-connect-base/include/etc/confluent/docker/run
+++ b/kafka-connect-base/include/etc/confluent/docker/run
@@ -19,9 +19,6 @@
 . /etc/confluent/docker/mesos-setup.sh
 . /etc/confluent/docker/apply-mesos-overrides
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 

--- a/kafka/include/etc/confluent/docker/run
+++ b/kafka/include/etc/confluent/docker/run
@@ -25,9 +25,6 @@ if [ $# -ne 0 ]; then
   done
 fi
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 

--- a/server-connect-base/include/etc/confluent/docker/run
+++ b/server-connect-base/include/etc/confluent/docker/run
@@ -19,9 +19,6 @@
 . /etc/confluent/docker/mesos-setup.sh
 . /etc/confluent/docker/apply-mesos-overrides
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 

--- a/server/include/etc/confluent/docker/run
+++ b/server/include/etc/confluent/docker/run
@@ -25,9 +25,6 @@ if [ $# -ne 0 ]; then
   done
 fi
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 

--- a/zookeeper/include/etc/confluent/docker/run
+++ b/zookeeper/include/etc/confluent/docker/run
@@ -16,9 +16,6 @@
 
 . /etc/confluent/docker/bash-config
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 


### PR DESCRIPTION
We don't want to print the environment variables in the logs during startup because they contain sensitive data.