### PR TITLE
Stop installing connectors through OS Packages

### DIFF
--- a/kafka-connect/Dockerfile.deb8
+++ b/kafka-connect/Dockerfile.deb8
@@ -48,12 +48,6 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get update \
     && apt-get install -y apt-transport-https \
     && apt-get install -y procps \
-    && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
-    && apt-get install -y confluent-kafka-connect-jdbc=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-kafka-connect-elasticsearch=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-kafka-connect-storage-common=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-kafka-connect-s3=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-kafka-connect-jms=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..."  \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*
 

--- a/kafka-connect/Dockerfile.ubi8
+++ b/kafka-connect/Dockerfile.ubi8
@@ -45,13 +45,6 @@ USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && yum -q -y update \
-    && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
-    && yum install -y \
-        confluent-kafka-connect-jdbc-${CONFLUENT_VERSION} \
-        confluent-kafka-connect-elasticsearch-${CONFLUENT_VERSION} \
-        confluent-kafka-connect-storage-common-${CONFLUENT_VERSION} \
-        confluent-kafka-connect-s3-${CONFLUENT_VERSION} \
-        confluent-kafka-connect-jms-${CONFLUENT_VERSION} \
     && echo "===> Cleaning up ..." \
     && yum clean all \
     && rm -rf /tmp/*

--- a/server-connect/Dockerfile.deb8
+++ b/server-connect/Dockerfile.deb8
@@ -47,12 +47,6 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get -qq update \
     && apt-get install -y apt-transport-https \
     && apt-get install -y procps \
-    && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
-    && apt-get install -y confluent-kafka-connect-jdbc=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-kafka-connect-elasticsearch=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-kafka-connect-storage-common=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-kafka-connect-s3=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
-    confluent-kafka-connect-jms=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*
 

--- a/server-connect/Dockerfile.ubi8
+++ b/server-connect/Dockerfile.ubi8
@@ -45,13 +45,6 @@ USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && yum -q -y update \
-    && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
-    && yum install -y \
-        confluent-kafka-connect-jdbc-${CONFLUENT_VERSION} \
-        confluent-kafka-connect-elasticsearch-${CONFLUENT_VERSION} \
-        confluent-kafka-connect-storage-common-${CONFLUENT_VERSION} \
-        confluent-kafka-connect-s3-${CONFLUENT_VERSION} \
-        confluent-kafka-connect-jms-${CONFLUENT_VERSION} \
     && echo "===> Cleaning up ..." \
     && yum clean all \
     && rm -rf /tmp/*


### PR DESCRIPTION
Fixing these build failures now that the connector OS packages are no longer being built: https://jenkins.confluent.io/job/confluentinc/job/kafka-images/job/master/137/console