### PR TITLE
[ST-3964] create /usr/share/confluent-hub-components directory in UBI images

### DIFF
--- a/kafka-connect-base/Dockerfile.ubi8
+++ b/kafka-connect-base/Dockerfile.ubi8
@@ -60,7 +60,9 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && echo "===> Setting up ${COMPONENT} dirs ..." \
     && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
     && chown appuser:appuser -R /etc/${COMPONENT} \
-    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
+    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
+    && mkdir -p /usr/share/confluent-hub-components \
+    && chown appuser:appuser -R /usr/share/confluent-hub-components
 
 VOLUME ["/etc/${COMPONENT}/jars", "/etc/${COMPONENT}/secrets"]
 

--- a/server-connect-base/Dockerfile.ubi8
+++ b/server-connect-base/Dockerfile.ubi8
@@ -62,7 +62,9 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && echo "===> Setting up ${COMPONENT} dirs ..." \
     && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars /usr/logs \
     && chown appuser:appuser -R /etc/${COMPONENT} /usr/logs \
-    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
+    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
+    && mkdir -p /usr/share/confluent-hub-components \
+    && chown appuser:appuser -R /usr/share/confluent-hub-components
 
 ENV CONNECT_PLUGIN_PATH=/usr/share/java/,/usr/share/confluent-hub-components/
 


### PR DESCRIPTION
Currently with UBI images, we don't have /usr/share/confluent-hub-components created by default and appuser doesn't have permissions to create the directory, so confluent hub installs will fail (without providing an existing target directory).  
