### PR TITLE
modify SR permissions for connect-hub installs

### DIFF
--- a/kafka-connect-base/Dockerfile.ubi8
+++ b/kafka-connect-base/Dockerfile.ubi8
@@ -60,7 +60,8 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && echo "===> Setting up ${COMPONENT} dirs ..." \
     && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
     && chown appuser:appuser -R /etc/${COMPONENT} \
-    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
+    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
+    && chmod -R ag+w /etc/schema-registry
 
 VOLUME ["/etc/${COMPONENT}/jars", "/etc/${COMPONENT}/secrets"]
 

--- a/server-connect-base/Dockerfile.ubi8
+++ b/server-connect-base/Dockerfile.ubi8
@@ -62,7 +62,8 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && echo "===> Setting up ${COMPONENT} dirs ..." \
     && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars /usr/logs \
     && chown appuser:appuser -R /etc/${COMPONENT} /usr/logs \
-    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars
+    && chmod -R ag+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
+    && chmod -R ag+w /etc/schema-registry
 
 ENV CONNECT_PLUGIN_PATH=/usr/share/java/,/usr/share/confluent-hub-components/
 


### PR DESCRIPTION
When connectors are installed from confluent hub, they update the plugin path for worker configs.  This involves updating kafka files and schema-registry.  However with UBI images for connect, the user doesn't have write access to /etc/schema-registry.
 