### PR TITLE
Remove extra -%} in kafka.properties.

### DIFF
--- a/server/include/etc/confluent/docker/kafka.properties.template
+++ b/server/include/etc/confluent/docker/kafka.properties.template
@@ -25,7 +25,7 @@
 {% if env.get(k) != None -%}
 {{property}}={{env[k]}}
 {% endif -%}
-{% endfor -%}-%}
+{% endfor -%}
 
 {% set confluent_support_props = env_to_props('CONFLUENT_SUPPORT_', 'confluent.support.') -%}
 {% for name, value in confluent_support_props.items() -%}


### PR DESCRIPTION
The extra `-%}` is copied as a literal in the final kafka.properties file. That results in a config named `-%}` being created. This config is problematic for REST Proxy, because REST Proxy assumes all config names are URL safe, therefore it tries to construct an URL with this config name on it and it fails.