### PR TITLE
Remove scala version from names and use releasever in yum config

### DIFF
--- a/kafka/Dockerfile.deb8
+++ b/kafka/Dockerfile.deb8
@@ -34,7 +34,6 @@ ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
 ARG CONFLUENT_DEB_VERSION
 ARG ALLOW_UNSIGNED
-ARG SCALA_VERSION
 
 # allow arg override of required env params
 ARG KAFKA_ZOOKEEPER_CONNECT
@@ -56,7 +55,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && cat /etc/apt/sources.list \
     && apt-get install -y apt-transport-https \
     && apt-get update \
-    && apt-get install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && apt-get install -y confluent-kafka=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> clean up ..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     && echo "===> Setting up ${COMPONENT} dirs..." \

--- a/kafka/Dockerfile.ubi8
+++ b/kafka/Dockerfile.ubi8
@@ -37,7 +37,6 @@ LABEL io.confluent.docker.git.repo="confluentinc/kafka-images"
 ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
-ARG SCALA_VERSION
 
 # allow arg override of required env params
 ARG KAFKA_ZOOKEEPER_CONNECT
@@ -58,7 +57,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\
 name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/$$releasever \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 \n\
@@ -69,7 +68,7 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && yum install -y confluent-kafka-${SCALA_VERSION}-${CONFLUENT_VERSION} \
+    && yum install -y confluent-kafka-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
     && yum clean all \
     && rm -rf /tmp/* \

--- a/server/Dockerfile.ubi8
+++ b/server/Dockerfile.ubi8
@@ -57,7 +57,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\
 name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/$$releasever \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 \n\

--- a/zookeeper/Dockerfile.deb8
+++ b/zookeeper/Dockerfile.deb8
@@ -34,7 +34,6 @@ ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
 ARG CONFLUENT_DEB_VERSION
 ARG ALLOW_UNSIGNED
-ARG SCALA_VERSION
 
 EXPOSE 2181 2888 3888
 
@@ -48,7 +47,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && cat /etc/apt/sources.list \
     && apt-get install -y apt-transport-https \
     && apt-get -qq update \
-    && apt-get install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && apt-get install -y confluent-kafka=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> clean up ..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     && echo "===> Setting up ${COMPONENT} dirs" \

--- a/zookeeper/Dockerfile.ubi8
+++ b/zookeeper/Dockerfile.ubi8
@@ -37,7 +37,6 @@ LABEL io.confluent.docker.git.repo="confluentinc/kafka-images"
 ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
-ARG SCALA_VERSION
 
 EXPOSE 2181 2888 3888
 
@@ -51,7 +50,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\
 name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/$$releasever \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 \n\
@@ -62,7 +61,7 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && yum install -y confluent-kafka-${SCALA_VERSION}-${CONFLUENT_VERSION} \
+    && yum install -y confluent-kafka-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
     && yum clean all \
     && rm -rf /tmp/* \


### PR DESCRIPTION
The upcomming 6.0.0 release removes the scala version from package names. ie: This PR fixes this failure:

https://jenkins.confluent.io/job/confluentinc/job/kafka-images/job/6.0.x/49/consoleFull

```
13:45:11  [INFO] E: Unable to locate package confluent-kafka-2.12
13:45:11  [INFO] E: Couldn't find any package by regex 'confluent-kafka-2.12'
13:45:11  [INFO] 
[2020-07-14T20:45:11.624Z] [ERROR] The command '/bin/sh -c echo "===> Installing ${COMPONENT}..."     && apt-get update     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}"     && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi     && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list     && cat /etc/apt/sources.list     && apt-get install -y apt-transport-https     && apt-get -qq update     && apt-get install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION}     && echo "===> clean up ..."     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*     && echo "===> Setting up ${COMPONENT} dirs"     && mkdir -p /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets     && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets     && chown -R root:root /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper' returned a non-zero code: 100
```