### PR TITLE
remove references to scala version for 6.0.x+

### DIFF
--- a/kafka/Dockerfile.deb8
+++ b/kafka/Dockerfile.deb8
@@ -34,7 +34,6 @@ ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
 ARG CONFLUENT_DEB_VERSION
 ARG ALLOW_UNSIGNED
-ARG SCALA_VERSION
 
 # allow arg override of required env params
 ARG KAFKA_ZOOKEEPER_CONNECT
@@ -56,7 +55,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && cat /etc/apt/sources.list \
     && apt-get install -y apt-transport-https \
     && apt-get update \
-    && apt-get install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && apt-get install -y confluent-kafka=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> clean up ..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     && echo "===> Setting up ${COMPONENT} dirs..." \

--- a/kafka/Dockerfile.ubi8
+++ b/kafka/Dockerfile.ubi8
@@ -37,7 +37,6 @@ LABEL io.confluent.docker.git.repo="confluentinc/kafka-images"
 ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
-ARG SCALA_VERSION
 
 # allow arg override of required env params
 ARG KAFKA_ZOOKEEPER_CONNECT
@@ -69,7 +68,7 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && yum install -y confluent-kafka-${SCALA_VERSION}-${CONFLUENT_VERSION} \
+    && yum install -y confluent-kafka-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
     && yum clean all \
     && rm -rf /tmp/* \

--- a/zookeeper/Dockerfile.deb8
+++ b/zookeeper/Dockerfile.deb8
@@ -34,7 +34,6 @@ ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
 ARG CONFLUENT_DEB_VERSION
 ARG ALLOW_UNSIGNED
-ARG SCALA_VERSION
 
 EXPOSE 2181 2888 3888
 
@@ -48,7 +47,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && cat /etc/apt/sources.list \
     && apt-get install -y apt-transport-https \
     && apt-get -qq update \
-    && apt-get install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
+    && apt-get install -y confluent-kafka=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> clean up ..." \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     && echo "===> Setting up ${COMPONENT} dirs" \

--- a/zookeeper/Dockerfile.ubi8
+++ b/zookeeper/Dockerfile.ubi8
@@ -37,7 +37,6 @@ LABEL io.confluent.docker.git.repo="confluentinc/kafka-images"
 ARG CONFLUENT_VERSION
 ARG CONFLUENT_PACKAGES_REPO
 ARG CONFLUENT_PLATFORM_LABEL
-ARG SCALA_VERSION
 
 EXPOSE 2181 2888 3888
 
@@ -62,7 +61,7 @@ baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
-    && yum install -y confluent-kafka-${SCALA_VERSION}-${CONFLUENT_VERSION} \
+    && yum install -y confluent-kafka-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
     && yum clean all \
     && rm -rf /tmp/* \


### PR DESCRIPTION
As Confluent Kafka will no longer specific the scala version, removing references here.