### PR TITLE
MINOR: Don't yum update & use $releasever in yum config

### DIFF
--- a/ce-kafka/Dockerfile.ubi8
+++ b/ce-kafka/Dockerfile.ubi8
@@ -47,7 +47,6 @@ EXPOSE 9092
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> installing confluent-rebalancer ..." \
     && yum install -y confluent-rebalancer-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \

--- a/kafka-connect-base/Dockerfile.ubi8
+++ b/kafka-connect-base/Dockerfile.ubi8
@@ -47,7 +47,6 @@ EXPOSE 8083
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Installing Schema Registry (for Avro jars) ..." \
     && yum install -y confluent-schema-registry-${CONFLUENT_VERSION} \
     && echo "===> Installing Controlcenter for monitoring interceptors ..." \

--- a/kafka-connect/Dockerfile.ubi8
+++ b/kafka-connect/Dockerfile.ubi8
@@ -44,7 +44,6 @@ ENV COMPONENT=kafka-connect
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Cleaning up ..." \
     && yum clean all \
     && rm -rf /tmp/*

--- a/kafka/Dockerfile.ubi8
+++ b/kafka/Dockerfile.ubi8
@@ -56,7 +56,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\
 name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/$$releasever \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/\$releasever \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 \n\

--- a/kafka/Dockerfile.ubi8
+++ b/kafka/Dockerfile.ubi8
@@ -52,12 +52,11 @@ EXPOSE 9092
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\
 name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/$$releasever \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 \n\

--- a/server-connect-base/Dockerfile.ubi8
+++ b/server-connect-base/Dockerfile.ubi8
@@ -47,7 +47,6 @@ EXPOSE 8083
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Installing Schema Registry (for Avro jars) ..." \
     && yum install -y confluent-schema-registry-${CONFLUENT_VERSION} \
     && echo "===> Installing Controlcenter for monitoring interceptors ..."\

--- a/server-connect/Dockerfile.ubi8
+++ b/server-connect/Dockerfile.ubi8
@@ -43,10 +43,4 @@ ENV COMPONENT=kafka-connect
 
 USER root
 
-RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
-    && echo "===> Cleaning up ..." \
-    && yum clean all \
-    && rm -rf /tmp/*
-
 USER appuser

--- a/server/Dockerfile.ubi8
+++ b/server/Dockerfile.ubi8
@@ -56,7 +56,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\
 name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/$$releasever \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/\$releasever \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 \n\

--- a/server/Dockerfile.ubi8
+++ b/server/Dockerfile.ubi8
@@ -52,12 +52,11 @@ EXPOSE 9092
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\
 name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/$$releasever \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 \n\

--- a/zookeeper/Dockerfile.ubi8
+++ b/zookeeper/Dockerfile.ubi8
@@ -49,7 +49,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\
 name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/$$releasever \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/\$releasever \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 \n\

--- a/zookeeper/Dockerfile.ubi8
+++ b/zookeeper/Dockerfile.ubi8
@@ -45,12 +45,11 @@ ENV COMPONENT=zookeeper
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\
 name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/$$releasever \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 \n\


### PR DESCRIPTION
From https://github.com/confluentinc/common-docker/pull/100

We shouldn't be calling `yum update` as other non-pinned dependencies (like zulu11 JDK) can be unknowingly updated.

For 6.0.x we are also building EL8 Clients, so we can now utilize yum var's `$releasever` to point to the EL8's package's endpoint, rather than the work around we were doing for 5.4.x/5.5.x and using EL7's endpoint.