### PR TITLE
ST-4157: Don't yum update

### DIFF
--- a/ce-kafka/Dockerfile.ubi8
+++ b/ce-kafka/Dockerfile.ubi8
@@ -47,7 +47,6 @@ EXPOSE 9092
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> installing confluent-rebalancer ..." \
     && yum install -y confluent-rebalancer-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \

--- a/kafka-connect-base/Dockerfile.ubi8
+++ b/kafka-connect-base/Dockerfile.ubi8
@@ -47,7 +47,6 @@ EXPOSE 8083
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Installing Schema Registry (for Avro jars) ..." \
     && yum install -y confluent-schema-registry-${CONFLUENT_VERSION} \
     && echo "===> Installing Controlcenter for monitoring interceptors ..." \

--- a/kafka-connect/Dockerfile.ubi8
+++ b/kafka-connect/Dockerfile.ubi8
@@ -44,7 +44,6 @@ ENV COMPONENT=kafka-connect
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
     && yum install -y \
         confluent-kafka-connect-jdbc-${CONFLUENT_VERSION} \

--- a/kafka/Dockerfile.ubi8
+++ b/kafka/Dockerfile.ubi8
@@ -53,7 +53,6 @@ EXPOSE 9092
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\

--- a/server-connect-base/Dockerfile.ubi8
+++ b/server-connect-base/Dockerfile.ubi8
@@ -47,7 +47,6 @@ EXPOSE 8083
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Installing Schema Registry (for Avro jars) ..." \
     && yum install -y confluent-schema-registry-${CONFLUENT_VERSION} \
     && echo "===> Installing Controlcenter for monitoring interceptors ..."\

--- a/server-connect/Dockerfile.ubi8
+++ b/server-connect/Dockerfile.ubi8
@@ -44,7 +44,6 @@ ENV COMPONENT=kafka-connect
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
     && yum install -y \
         confluent-kafka-connect-jdbc-${CONFLUENT_VERSION} \

--- a/server/Dockerfile.ubi8
+++ b/server/Dockerfile.ubi8
@@ -52,7 +52,6 @@ EXPOSE 9092
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\

--- a/zookeeper/Dockerfile.ubi8
+++ b/zookeeper/Dockerfile.ubi8
@@ -46,7 +46,6 @@ ENV COMPONENT=zookeeper
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\


### PR DESCRIPTION
"Backporting" https://github.com/confluentinc/kafka-images/pull/51

* Don't run `yum update` - thats done in the base image: https://github.com/confluentinc/common-docker/pull/101
* Didn't backport the `$releasever` change, as we're not generating EL8 Clients for 5.4/5.5 - These CP versions will use the EL7 RPMs. Redhat is generally backards ABI compatible.