### PR TITLE
ST-3461: Implement nano versioning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,4 +16,5 @@ dockerfile {
     cron = '' // Disable the cron because this job requires parameters
     cpImages = true
     osTypes = ['ubi8']
+    nanoVersion = true
 }

--- a/ce-kafka/pom.xml
+++ b/ce-kafka/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.kafka-images</groupId>
         <artifactId>kafka-images-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.kafka-images</groupId>

--- a/kafka-connect-base/pom.xml
+++ b/kafka-connect-base/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.kafka-images</groupId>
         <artifactId>kafka-images-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.kafka-images</groupId>

--- a/kafka-connect/pom.xml
+++ b/kafka-connect/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.kafka-images</groupId>
         <artifactId>kafka-images-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.kafka-images</groupId>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.kafka-images</groupId>
         <artifactId>kafka-images-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.kafka-images</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>[6.1.0-0, 6.1.1-0)</version>
     </parent>
 
     <groupId>io.confluent.kafka-images</groupId>
@@ -30,7 +30,7 @@
     <packaging>pom</packaging>
     <name>Kafka and CE Kafka Docker Images</name>
     <description>Build files for Confluent's Kafka Docker images</description>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0-0</version>
 
     <modules>
         <module>zookeeper</module>

--- a/server-connect-base/pom.xml
+++ b/server-connect-base/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.kafka-images</groupId>
         <artifactId>kafka-images-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.kafka-images</groupId>

--- a/server-connect/pom.xml
+++ b/server-connect/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.kafka-images</groupId>
         <artifactId>kafka-images-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.kafka-images</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.kafka-images</groupId>
         <artifactId>kafka-images-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.kafka-images</groupId>

--- a/zookeeper/pom.xml
+++ b/zookeeper/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.kafka-images</groupId>
         <artifactId>kafka-images-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.kafka-images</groupId>


### PR DESCRIPTION
Setting the jenkins config to use nano versioning. Removed all of the snapshot versions and replaced with nano versions. Updated all of the dependency versions.

These changes will be merged during phase two of the nano versioning roll out.