### PR TITLE
[ST-4294] update folder ownership for UBI8 images

### DIFF
--- a/kafka/Dockerfile.ubi8
+++ b/kafka/Dockerfile.ubi8
@@ -73,8 +73,8 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && rm -rf /tmp/* \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
-    && chown appuser:appuser -R /var/lib/${COMPONENT} /etc/${COMPONENT} \
-    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets
+    && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
+    && chown -R appuser:appuser /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper /etc/${COMPONENT}/secrets
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/etc/${COMPONENT}/secrets"]
 


### PR DESCRIPTION
with UBI images, the appuser doens't have permissions directly to /var/log and this causes startup issues in 2.6/6.0, so fixing (this is the same as the permissions in the server image already).

Verified with cp-all-in-one-community with a local build.