### PR TITLE
Add missing path back

### DIFF
--- a/kafka-connect-base/Dockerfile.ubi8
+++ b/kafka-connect-base/Dockerfile.ubi8
@@ -64,6 +64,8 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && mkdir -p /usr/share/confluent-hub-components \
     && chown appuser:appuser -R /usr/share/confluent-hub-components
 
+ENV CONNECT_PLUGIN_PATH=/usr/share/java/,/usr/share/confluent-hub-components/
+
 VOLUME ["/etc/${COMPONENT}/jars", "/etc/${COMPONENT}/secrets"]
 
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker


### PR DESCRIPTION
Why

kafka-connect-image missing `CONNECT_PLUGIN_PATH ` while server-connect-base still have that path. It might get removed mistakenly during deb to ubi transfer. https://github.com/confluentinc/kafka-images/pull/9/files#diff-b0c4beb1277b361ec5ab6f6c4fc6760fb10f1f82f03aaa56d5fdff2d0a8921b8L65

How

Add the missing path back to the kafka-connect-base image, that change will be merged up to master branch.