### PR TITLE
Fix READMEs (DOCS-6716)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# Docker images for Kafka
+# Docker images for Apache Kafka
 
-This repo provides build files for [Kafka](https://www.confluent.io/what-is-apache-kafka/) Docker images.
+This repo provides build files for [Apache Kafka](https://www.confluent.io/what-is-apache-kafka/) and Confluent Docker images. The images can be found on [Docker Hub](https://hub.docker.com/u/confluentinc/), and sample Docker Compose files [here](examples).
 
-## Properties
+## Docker Image reference
+
+Information on using the Docker images is available in [the documentation](https://docs.confluent.io/platform/current/installation/docker/installation.html). 
+
+## Build files
+### Properties
 
 Properties are inherited from a top-level POM. Properties may be overridden on the command line (`-Ddocker.registry=testing.example.com:8080/`), or in a subproject's POM.
 
@@ -19,7 +24,7 @@ Properties are inherited from a top-level POM. Properties may be overridden on t
 - *CONFLUENT_VERSION*: (Required) Specify the full Confluent Platform release version. Example: 5.4.0
 
 
-## Building
+### Building
 
 This project uses `maven-assembly-plugin` and `dockerfile-maven-plugin` to build Docker images via Maven.
 

--- a/ce-kafka/README.md
+++ b/ce-kafka/README.md
@@ -1,0 +1,35 @@
+# Confluent Enterprise Docker Image for Apache Kafka [Deprecated]
+
+**Whilst still published, this image is deprecated in favor of [cp-server](https://hub.docker.com/r/confluentinc/cp-server)**
+
+----
+
+Docker image for deploying and running the Enterprise Version of Kafka packaged with the Confluent Platform download. Please see the [cp-server](https://hub.docker.com/r/confluentinc/cp-server) image for additional commercial features that are only part of [Confluent Server](https://docs.confluent.io/platform/current/installation/available_packages.html#confluent-server).
+
+## Using the image
+
+* [Notes on using the image](https://docs.confluent.io/platform/current/installation/docker/installation.html) 
+* [Configuration Reference](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#confluent-enterprise-ak-configuration)
+
+## Resources
+
+* [Docker Quick Start for Apache Kafka using Confluent Platform](https://docs.confluent.io/platform/current/quickstart/ce-docker-quickstart.html#ce-docker-quickstart)
+
+* [Learn Kafka](https://developer.confluent.io/learn-kafka)
+
+* [Confluent Developer](https://developer.confluent.io): blogs, tutorials, videos, and podcasts for learning all about Apache Kafka and Confluent Platform
+
+* [confluentinc/cp-demo](https://github.com/confluentinc/cp-demo): GitHub demo that you can run locally. The demo uses this Docker image to showcase Confluent Server in a secured, end-to-end event streaming platform. It has an accompanying playbook that shows users how to use Confluent Control Center to manage and monitor Kafka connect, Schema Registry, REST Proxy, KSQL, and Kafka Streams.
+
+* [confluentinc/examples](https://github.com/confluentinc/examples): additional curated examples in GitHub that you can run locally.
+
+## Contribute
+
+Start by reading our guidelines on contributing to this project found here.
+
+* [Source Code](https://github.com/confluentinc/kafka-images)
+* [Issue Tracker](https://github.com/confluentinc/kafka-images/issues)
+
+## License
+
+This Docker image is licensed under the Apache 2 license. For more information on the licenses for each of the individual Confluent Platform components packaged in this image, please refer to the respective [Confluent Platform documentation](https://docs.confluent.io/platform/current/installation/docker/image-reference.html).

--- a/ce-kafka/README.md
+++ b/ce-kafka/README.md
@@ -1,6 +1,6 @@
 # Confluent Enterprise Docker Image for Apache Kafka [Deprecated]
 
-**Whilst still published, this image is deprecated in favor of [cp-server](https://hub.docker.com/r/confluentinc/cp-server)**
+**This image is deprecated in favor of [cp-server](https://hub.docker.com/r/confluentinc/cp-server)**
 
 ----
 

--- a/kafka-connect-base/README.md
+++ b/kafka-connect-base/README.md
@@ -2,7 +2,7 @@
 
 Docker image for deploying and running Kafka Connect. 
 
-_Functionally, the `cp-kafka-connect` and the `cp-kafka-connect-base` images are identical. Prior to Confluent Platform 6.0 the `cp-kafka-connect` image included several connectors pre-installed, but this is no longer the case._
+_Functionally, the `cp-kafka-connect` and the `cp-kafka-connect-base` images are identical. Prior to Confluent Platform 6.0 the `cp-kafka-connect` image included several connectors pre-installed, but **this is no longer the case**._
 
 ## What is Kafka Connect?
 
@@ -25,6 +25,7 @@ You will need to install plugins into the image in order to use them. This can b
 ### Configuration
 
 [Reference](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#kconnect-long-configuration)
+
 ## Contribute
 
 Start by reading our guidelines on contributing to this project found here.

--- a/kafka-connect/README.md
+++ b/kafka-connect/README.md
@@ -1,18 +1,18 @@
 # Confluent Docker Image for Kafka Connect
 
-Docker image for deploying and running the Kafka Connect. The source code is currently available on [Github](https://github.com/confluentinc/cp-docker-images/).
+Docker image for deploying and running the Kafka Connect. The source code is currently available on [Github](https://github.com/confluentinc/kafka-images/).
 
-Please see the [Confluent Platform documentation](http://docs.confluent.io/current/cp-docker-images/docs/intro.html) for documentation on these images - including quickstart guides, Docker Compose configs, reference documentation and advanced tutorials.
+Please see the [Confluent Platform documentation](https://docs.confluent.io/platform/current/installation/docker/installation.html) for documentation on these images - including quickstart guides, Docker Compose configs, reference documentation and advanced tutorials.
 
 Functionally, the cp-kafka-connect and the cp-kafka-connect-base images are identical. The only difference is that the cp-kafka-connect image already contains several of Confluent’s connectors, whereas the cp-kafka-connect-base image comes with none by default.
 
-# Contribute
+## Contribute
 
 Start by reading our guidelines on contributing to this project found here.
 
-* Source Code: https://github.com/confluentinc/cp-docker-images
-* Issue Tracker: https://github.com/confluentinc/cp-docker-images/issues
+* Source Code: https://github.com/confluentinc/kafka-images
+* Issue Tracker: https://github.com/confluentinc/kafka-images/issues
 
-# License
+## License
 
-This Docker image is licensed under the Apache 2 license. For more information on the licenses for each of the individual Confluent Platform components packaged in this image, please refer to the respective [Confluent Platform documentation](https://docs.confluent.io/current/installation/docker/docs/image-reference.html).
+This Docker image is licensed under the Apache 2 license. For more information on the licenses for each of the individual Confluent Platform components packaged in this image, please refer to the respective [Confluent Platform documentation](https://docs.confluent.io/platform/current/installation/docker/image-reference.html).

--- a/kafka-connect/README.md
+++ b/kafka-connect/README.md
@@ -1,0 +1,18 @@
+# Confluent Docker Image for Kafka Connect
+
+Docker image for deploying and running the Kafka Connect. The source code is currently available on [Github](https://github.com/confluentinc/cp-docker-images/).
+
+Please see the [Confluent Platform documentation](http://docs.confluent.io/current/cp-docker-images/docs/intro.html) for documentation on these images - including quickstart guides, Docker Compose configs, reference documentation and advanced tutorials.
+
+Functionally, the cp-kafka-connect and the cp-kafka-connect-base images are identical. The only difference is that the cp-kafka-connect image already contains several of Confluent’s connectors, whereas the cp-kafka-connect-base image comes with none by default.
+
+# Contribute
+
+Start by reading our guidelines on contributing to this project found here.
+
+* Source Code: https://github.com/confluentinc/cp-docker-images
+* Issue Tracker: https://github.com/confluentinc/cp-docker-images/issues
+
+# License
+
+This Docker image is licensed under the Apache 2 license. For more information on the licenses for each of the individual Confluent Platform components packaged in this image, please refer to the respective [Confluent Platform documentation](https://docs.confluent.io/current/installation/docker/docs/image-reference.html).

--- a/kafka-connect/README.md
+++ b/kafka-connect/README.md
@@ -1,11 +1,28 @@
 # Confluent Docker Image for Kafka Connect
 
-Docker image for deploying and running the Kafka Connect. The source code is currently available on [Github](https://github.com/confluentinc/kafka-images/).
+Docker image for deploying and running the Kafka Connect. 
 
-Please see the [Confluent Platform documentation](https://docs.confluent.io/platform/current/installation/docker/installation.html) for documentation on these images - including quickstart guides, Docker Compose configs, reference documentation and advanced tutorials.
+_Functionally, the `cp-kafka-connect` and the `cp-kafka-connect-base` images are identical. Prior to Confluent Platform 6.0 the `cp-kafka-connect` image included several connectors pre-installed, but this is no longer the case._
+## What is Kafka Connect?
 
-Functionally, the cp-kafka-connect and the cp-kafka-connect-base images are identical. The only difference is that the cp-kafka-connect image already contains several of Confluent’s connectors, whereas the cp-kafka-connect-base image comes with none by default.
+Kafka Connect is part of Apache Kafka, and is used to integrate external systems with Kafka. You can find out more in [the documentation](https://docs.confluent.io/platform/current/connect/index.html#what-is-kafka-connect) and [this short video](https://rmoff.dev/what-is-kafka-connect).
+## Using the image
 
+Please see the [Confluent Platform documentation](https://docs.confluent.io/platform/current/installation/docker/installation.html) for further documentation on these images.
+
+### Installing connectors
+
+Kafka Connect is a pluggable framework with which you can use plugins for different connectors, transformations, and converters. You can find hundreds of these at [Confluent Hub](https://hub.confluent.io).
+
+You will need to install plugins into the image in order to use them. This can be done in several ways: 
+
+1. [Extend the image](https://docs.confluent.io/platform/current/installation/docker/development.html#extending-images)
+2. Add the connector JARs via volumes mounted to the image ([example](https://github.com/confluentinc/demo-scene/blob/master/kafka-connect-zero-to-hero/docker-compose.yml#L82-L87))
+3. Install the connector JARs at runtime ([example](https://github.com/confluentinc/demo-scene/blob/master/kafka-connect-zero-to-hero/docker-compose.yml#L89-L101))
+
+### Configuration
+
+[Reference](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#kconnect-long-configuration)
 ## Contribute
 
 Start by reading our guidelines on contributing to this project found here.

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -1,0 +1,31 @@
+# Confluent Community Docker Image for Apache Kafka
+
+Docker image for deploying and running the Community Version of Kafka packaged with the Confluent Community download. Please see the [cp-server](https://hub.docker.com/r/confluentinc/cp-server) image for additional commercial features that are only part of [Confluent Server](https://docs.confluent.io/platform/current/installation/available_packages.html#confluent-server).
+
+## Using the image
+
+* [Notes on using the image](https://docs.confluent.io/platform/current/installation/docker/installation.html) 
+* [Configuration Reference](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#confluent-ak-configuration)
+
+## Resources
+
+* [Docker Quick Start for Apache Kafka using Confluent Platform](https://docs.confluent.io/platform/current/quickstart/ce-docker-quickstart.html#ce-docker-quickstart)
+
+* [Learn Kafka](https://developer.confluent.io/learn-kafka)
+
+* [Confluent Developer](https://developer.confluent.io): blogs, tutorials, videos, and podcasts for learning all about Apache Kafka and Confluent Platform
+
+* [confluentinc/cp-demo](https://github.com/confluentinc/cp-demo): GitHub demo that you can run locally. The demo uses this Docker image to showcase Confluent Server in a secured, end-to-end event streaming platform. It has an accompanying playbook that shows users how to use Confluent Control Center to manage and monitor Kafka connect, Schema Registry, REST Proxy, KSQL, and Kafka Streams.
+
+* [confluentinc/examples](https://github.com/confluentinc/examples): additional curated examples in GitHub that you can run locally.
+
+## Contribute
+
+Start by reading our guidelines on contributing to this project found here.
+
+* [Source Code](https://github.com/confluentinc/kafka-images)
+* [Issue Tracker](https://github.com/confluentinc/kafka-images/issues)
+
+## License
+
+This Docker image is licensed under the Apache 2 license. For more information on the licenses for each of the individual Confluent Platform components packaged in this image, please refer to the respective [Confluent Platform documentation](https://docs.confluent.io/platform/current/installation/docker/image-reference.html).

--- a/server-connect-base/README.md
+++ b/server-connect-base/README.md
@@ -1,8 +1,8 @@
-# Confluent Docker Image for Kafka Connect
+# Confluent Server Docker Image for Kafka Connect
 
 Docker image for deploying and running Kafka Connect. 
 
-_Functionally, the `cp-kafka-connect` and the `cp-kafka-connect-base` images are identical. Prior to Confluent Platform 6.0 the `cp-kafka-connect` image included several connectors pre-installed, but this is no longer the case._
+_Functionally, the `cp-server-connect` and the `cp-server-connect-base` images are identical. Prior to Confluent Platform 6.0 the `cp-server-connect` image included several connectors pre-installed, but **this is no longer the case**._
 
 ## What is Kafka Connect?
 
@@ -25,6 +25,7 @@ You will need to install plugins into the image in order to use them. This can b
 ### Configuration
 
 [Reference](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#kconnect-long-configuration)
+
 ## Contribute
 
 Start by reading our guidelines on contributing to this project found here.

--- a/server-connect/README.md
+++ b/server-connect/README.md
@@ -1,8 +1,8 @@
-# Confluent Docker Image for Kafka Connect
+# Confluent Server Docker Image for Kafka Connect
 
 Docker image for deploying and running Kafka Connect. 
 
-_Functionally, the `cp-kafka-connect` and the `cp-kafka-connect-base` images are identical. Prior to Confluent Platform 6.0 the `cp-kafka-connect` image included several connectors pre-installed, but this is no longer the case._
+_Functionally, the `cp-server-connect` and the `cp-server-connect-base` images are identical. Prior to Confluent Platform 6.0 the `cp-server-connect` image included several connectors pre-installed, but **this is no longer the case**._
 
 ## What is Kafka Connect?
 
@@ -25,6 +25,7 @@ You will need to install plugins into the image in order to use them. This can b
 ### Configuration
 
 [Reference](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#kconnect-long-configuration)
+
 ## Contribute
 
 Start by reading our guidelines on contributing to this project found here.

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,42 @@
+# Confluent Server Docker Image
+
+Docker image for deploying and running [Confluent Server](https://docs.confluent.io/platform/current/installation/available_packages.html#confluent-server). Please see the [cp-kafka](https://hub.docker.com/r/confluentinc/cp-kafka) image for the Community Version of Apache Kafka packaged with the Confluent Community download.
+
+Confluent Server is a component of Confluent Platform that includes Kafka and additional commercial features. The following is a few key features included in Confluent Server:
+
+* Role-based access control (RBAC)
+* LDAP Authorizer
+* Tiered Storage
+* Self-Balancing Clusters
+
+Confluent Server is fully compatible with Kafka, and you can migrate in place between Confluent Server and Kafka. Confluent Server includes Kafka and a number of commercial features.
+
+Confluent Server is a commercial component of Confluent Platform.
+
+## Using the image
+
+* [Notes on using the image](https://docs.confluent.io/platform/current/installation/docker/installation.html) 
+* [Configuration Reference](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#confluent-enterprise-ak-configuration)
+
+## Resources
+
+* [Docker Quick Start for Apache Kafka using Confluent Platform](https://docs.confluent.io/platform/current/quickstart/ce-docker-quickstart.html#ce-docker-quickstart)
+
+* [Learn Kafka](https://developer.confluent.io/learn-kafka)
+
+* [Confluent Developer](https://developer.confluent.io): blogs, tutorials, videos, and podcasts for learning all about Apache Kafka and Confluent Platform
+
+* [confluentinc/cp-demo](https://github.com/confluentinc/cp-demo): GitHub demo that you can run locally. The demo uses this Docker image to showcase Confluent Server in a secured, end-to-end event streaming platform. It has an accompanying playbook that shows users how to use Confluent Control Center to manage and monitor Kafka connect, Schema Registry, REST Proxy, KSQL, and Kafka Streams.
+
+* [confluentinc/examples](https://github.com/confluentinc/examples): additional curated examples in GitHub that you can run locally.
+
+## Contribute
+
+Start by reading our guidelines on contributing to this project found here.
+
+* [Source Code](https://github.com/confluentinc/kafka-images)
+* [Issue Tracker](https://github.com/confluentinc/kafka-images/issues)
+
+## License
+
+This Docker image is licensed under the Apache 2 license. For more information on the licenses for each of the individual Confluent Platform components packaged in this image, please refer to the respective [Confluent Platform documentation](https://docs.confluent.io/platform/current/installation/docker/image-reference.html).

--- a/zookeeper/README.md
+++ b/zookeeper/README.md
@@ -1,0 +1,31 @@
+# Confluent Docker Image for Zookeeper
+
+Docker image for deploying and running Zookeeper.
+
+## Using the image
+
+* [Notes on using the image](https://docs.confluent.io/platform/current/installation/docker/installation.html) 
+* [Configuration Reference](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#zk-configuration)
+
+## Resources
+
+* [Docker Quick Start for Apache Kafka using Confluent Platform](https://docs.confluent.io/platform/current/quickstart/ce-docker-quickstart.html#ce-docker-quickstart)
+
+* [Learn Kafka](https://developer.confluent.io/learn-kafka)
+
+* [Confluent Developer](https://developer.confluent.io): blogs, tutorials, videos, and podcasts for learning all about Apache Kafka and Confluent Platform
+
+* [confluentinc/cp-demo](https://github.com/confluentinc/cp-demo): GitHub demo that you can run locally. The demo uses this Docker image to showcase Confluent Server in a secured, end-to-end event streaming platform. It has an accompanying playbook that shows users how to use Confluent Control Center to manage and monitor Kafka connect, Schema Registry, REST Proxy, KSQL, and Kafka Streams.
+
+* [confluentinc/examples](https://github.com/confluentinc/examples): additional curated examples in GitHub that you can run locally.
+
+## Contribute
+
+Start by reading our guidelines on contributing to this project found here.
+
+* [Source Code](https://github.com/confluentinc/kafka-images)
+* [Issue Tracker](https://github.com/confluentinc/kafka-images/issues)
+
+## License
+
+This Docker image is licensed under the Apache 2 license. For more information on the licenses for each of the individual Confluent Platform components packaged in this image, please refer to the respective [Confluent Platform documentation](https://docs.confluent.io/platform/current/installation/docker/image-reference.html).


### PR DESCRIPTION
This is the first step in fixing all of the README files. I've picked one and want to make sure the process is valid for updating them before proceeding with the others. 

/cc @elismaga please can you review, and let me know if this is an appropriate way to do it. I've committed the existing README in Markdown form for https://hub.docker.com/r/confluentinc/cp-kafka-connect and then subsequent edits to it. 

I noticed on DockerHub that it says that READMEs can be set automatically on build - is this something that our tooling would support? 