### PR TITLE
remove extraneous spaces from yum repo file

### DIFF
--- a/kafka/Dockerfile.ubi8
+++ b/kafka/Dockerfile.ubi8
@@ -54,19 +54,19 @@ USER root
 RUN echo "===> Installing ${COMPONENT}..." \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
-    && printf "[Confluent.dist] \n\
-name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/\$releasever \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 \n\
+    && printf "[Confluent.dist]\n\
+name=Confluent repository (dist)\n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/\$releasever\n\
+gpgcheck=1\n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key\n\
+enabled=1\n\
 \n\
-[Confluent] \n\
-name=Confluent repository \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 " > /etc/yum.repos.d/confluent.repo \
+[Confluent]\n\
+name=Confluent repository\n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/\n\
+gpgcheck=1\n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key\n\
+enabled=1" > /etc/yum.repos.d/confluent.repo \
     && yum install -y confluent-kafka-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
     && yum clean all \

--- a/server/Dockerfile.ubi8
+++ b/server/Dockerfile.ubi8
@@ -54,19 +54,19 @@ USER root
 RUN echo "===> Installing ${COMPONENT}..." \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
-    && printf "[Confluent.dist] \n\
-name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/\$releasever \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 \n\
+    && printf "[Confluent.dist]\n\
+name=Confluent repository (dist)\n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/\$releasever\n\
+gpgcheck=1\n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key\n\
+enabled=1\n\
 \n\
-[Confluent] \n\
-name=Confluent repository \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 " > /etc/yum.repos.d/confluent.repo \
+[Confluent]\n\
+name=Confluent repository\n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/\n\
+gpgcheck=1\n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key\n\
+enabled=1" > /etc/yum.repos.d/confluent.repo \
     && echo "===> installing ${COMPONENT}..." \
     && yum install -y confluent-server-${CONFLUENT_VERSION} \
     && echo "===> installing confluent-rebalancer ..." \

--- a/zookeeper/Dockerfile.ubi8
+++ b/zookeeper/Dockerfile.ubi8
@@ -47,19 +47,19 @@ USER root
 RUN echo "===> Installing ${COMPONENT}..." \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
-    && printf "[Confluent.dist] \n\
-name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/\$releasever \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 \n\
+    && printf "[Confluent.dist]\n\
+name=Confluent repository (dist)\n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/\$releasever\n\
+gpgcheck=1\n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key\n\
+enabled=1\n\
 \n\
-[Confluent] \n\
-name=Confluent repository \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 " > /etc/yum.repos.d/confluent.repo \
+[Confluent]\n\
+name=Confluent repository\n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/\n\
+gpgcheck=1\n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key\n\
+enabled=1" > /etc/yum.repos.d/confluent.repo\
     && yum install -y confluent-kafka-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
     && yum clean all \


### PR DESCRIPTION
A Dockerfile RUN command in each app creates a repo file used by UBI's
microdnf utility. There is currently a bug caused by having extra
whitespace after the boolean '1' values.

This commit removes the extraneous spaces before the newlines, which
should fix this problem.

An example of this failure is here: ```(microdnf:1): libdnf-WARNING **: 22:02:34.494: Config error in section "Confluent.dist" key "enabled": invalid boolean value '1 '```

It is reproducible by running the Docker image in an interactive shell and running `microdnf update` or `microdnf install net-tools`