### PR TITLE
Add description label to Dockerfiles

### DIFF
--- a/server-connect/Dockerfile.ubi8
+++ b/server-connect/Dockerfile.ubi8
@@ -29,6 +29,7 @@ LABEL version=$GIT_COMMIT
 LABEL release=$PROJECT_VERSION
 LABEL name=$ARTIFACT_ID
 LABEL summary="Confluent platform server connect image."
+LABEL description ="Confluent platform server connect image."
 LABEL io.confluent.docker=true
 LABEL io.confluent.docker.git.id=$GIT_COMMIT
 ARG BUILD_NUMBER=-1

--- a/server/Dockerfile.ubi8
+++ b/server/Dockerfile.ubi8
@@ -28,6 +28,7 @@ LABEL version=$GIT_COMMIT
 LABEL release=$PROJECT_VERSION
 LABEL name=$ARTIFACT_ID
 LABEL summary="Confluent platform server image."
+LABEL description="Confluent platform server image."
 LABEL io.confluent.docker=true
 LABEL io.confluent.docker.git.id=$GIT_COMMIT
 ARG BUILD_NUMBER=-1

--- a/zookeeper/Dockerfile.ubi8
+++ b/zookeeper/Dockerfile.ubi8
@@ -28,6 +28,7 @@ LABEL version=$GIT_COMMIT
 LABEL release=$PROJECT_VERSION
 LABEL name=$ARTIFACT_ID
 LABEL summary="ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services."
+LABEL description="ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services."
 LABEL io.confluent.docker=true
 LABEL io.confluent.docker.git.id=$GIT_COMMIT
 ARG BUILD_NUMBER=-1


### PR DESCRIPTION
Some image scanning tools that check for vulnerabilities and OCI image best
practices expect to find a `description` label on images that is _not_ inherited
from base images. The proposed change addresses this requirement for
ZooKeeper, CP Server, and CP Connect Server.