### PR TITLE
zookeeper: add 4lw_commands_whitelist as environment variable

### DIFF
--- a/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
+++ b/zookeeper/include/etc/confluent/docker/zookeeper.properties.template
@@ -69,7 +69,8 @@ dataLogDir=/var/lib/zookeeper/log
   'ZOOKEEPER_ADMIN_SERVER_ADDRESS' : 'admin.serverAddress',
   'ZOOKEEPER_ADMIN_SERVER_PORT' : 'admin.serverPort',
   'ZOOKEEPER_ADMIN_IDLE_TIMEOUT' : 'admin.idleTimeout',
-  'ZOOKEEPER_ADMIN_COMMAND_URL' : 'admin.commandURL'
+  'ZOOKEEPER_ADMIN_COMMAND_URL' : 'admin.commandURL',
+  '4LW___COMMANDS___WHITELIST': '4lw_commands_whitelist'
  } -%}
 
 {% for k, property in other_props.items() -%}


### PR DESCRIPTION
Add 4lw_commands_whitelist property to zookeeper property list.

I was surprised to not see this property configuration in this file.
The property `ZOOKEEPER_4LW_COMMANDS_WHITELIST` should be transformed to `4lw_commands_whitelist` according to the [documentation](https://hub.docker.com/r/confluentinc/cp-kafka/tags?page=1&ordering=last_updated).