### PR TITLE
build: Remove confluent yum/apt repo after installation

### DIFF
--- a/ce-kafka/Dockerfile.deb8
+++ b/ce-kafka/Dockerfile.deb8
@@ -43,15 +43,15 @@ EXPOSE 9092
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get update \
+    && apt-get install -y apt-transport-https software-properties-common \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
-    && apt-get install -y apt-transport-https \
+    && curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key | apt-key add - \
+    && apt-add-repository "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get update \
     && echo "===> installing confluent-rebalancer ..." \
     && apt-get install -y confluent-rebalancer=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> clean up ..." \
+    && apt-add-repository --remove "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     && echo "===> Setting up ${COMPONENT} dirs..." \
     && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\

--- a/ce-kafka/Dockerfile.ubi8
+++ b/ce-kafka/Dockerfile.ubi8
@@ -22,6 +22,7 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-kafka:${DOCKER_TAG}
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
+ARG CONFLUENT_PACKAGES_REPO
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"
@@ -47,11 +48,26 @@ EXPOSE 9092
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent.dist] \n\
+name=Confluent repository (dist) \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 \n\
+\n\
+[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && echo "===> installing confluent-rebalancer ..." \
     && yum install -y confluent-rebalancer-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
     && yum clean all \
-    && rm -rf /tmp/* \
+    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs  ..." \
     && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
     && chmod -R ag+w /etc/${COMPONENT} /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \

--- a/kafka-connect-base/Dockerfile.deb8
+++ b/kafka-connect-base/Dockerfile.deb8
@@ -44,11 +44,10 @@ EXPOSE 8083
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get update \
+    && apt-get install -y apt-transport-https software-properties-common  \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
-    && apt-get install -y apt-transport-https \
+    && curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key | apt-key add - \
+    && apt-add-repository "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get update \
     && echo "===> Installing Schema Registry (for Avro jars) ..." \
     && apt-get install -y confluent-schema-registry=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
@@ -57,6 +56,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && echo "===> Installing Confluent Hub client ..." \
     && apt-get install -y confluent-hub-client=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..." \
+    && apt-add-repository --remove "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     echo "===> Setting up ${COMPONENT} dirs ..." \
     && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \

--- a/kafka-connect-base/Dockerfile.ubi8
+++ b/kafka-connect-base/Dockerfile.ubi8
@@ -22,6 +22,7 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-kafka:${DOCKER_TAG}
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
+ARG CONFLUENT_PACKAGES_REPO
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"
@@ -47,6 +48,21 @@ EXPOSE 8083
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent.dist] \n\
+name=Confluent repository (dist) \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 \n\
+\n\
+[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && echo "===> Installing Schema Registry (for Avro jars) ..." \
     && yum install -y confluent-schema-registry-${CONFLUENT_VERSION} \
     && echo "===> Installing Controlcenter for monitoring interceptors ..." \
@@ -55,7 +71,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && yum install -y confluent-hub-client-${CONFLUENT_VERSION} \
     && echo "===> Cleaning up ..." \
     && yum clean all \
-    && rm -rf /tmp/* \
+    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs ..." \
     && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \
     && chown appuser:appuser -R /etc/${COMPONENT} \

--- a/kafka-connect/Dockerfile.deb8
+++ b/kafka-connect/Dockerfile.deb8
@@ -41,13 +41,11 @@ ENV COMPONENT=kafka-connect
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get update \
+    && apt-get install -y apt-transport-https software-properties-common procps \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
+    && curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key | apt-key add - \
+    && apt-add-repository "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get update \
-    && apt-get install -y apt-transport-https \
-    && apt-get install -y procps \
     && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
     && apt-get install -y confluent-kafka-connect-jdbc=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     confluent-kafka-connect-elasticsearch=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
@@ -55,6 +53,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     confluent-kafka-connect-s3=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     confluent-kafka-connect-jms=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..."  \
+    && apt-add-repository --remove "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*
 
 RUN echo "===> Installing GCS Sink Connector ..."

--- a/kafka-connect/Dockerfile.ubi8
+++ b/kafka-connect/Dockerfile.ubi8
@@ -44,6 +44,21 @@ ENV COMPONENT=kafka-connect
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent.dist] \n\
+name=Confluent repository (dist) \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 \n\
+\n\
+[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
     && yum install -y \
         confluent-kafka-connect-jdbc-${CONFLUENT_VERSION} \
@@ -53,7 +68,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
         confluent-kafka-connect-jms-${CONFLUENT_VERSION} \
     && echo "===> Cleaning up ..." \
     && yum clean all \
-    && rm -rf /tmp/*
+    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo
 
 RUN echo "===> Installing GCS Sink Connector ..." \
     && confluent-hub install confluentinc/kafka-connect-gcs:latest --no-prompt

--- a/kafka/Dockerfile.deb8
+++ b/kafka/Dockerfile.deb8
@@ -50,14 +50,14 @@ EXPOSE 9092
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get update \
+    && apt-get install -y apt-transport-https software-properties-common  \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
-    && apt-get install -y apt-transport-https \
+    && curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key | apt-key add - \
+    && apt-add-repository "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get update \
     && apt-get install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> clean up ..." \
+    && apt-add-repository --remove "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     && echo "===> Setting up ${COMPONENT} dirs..." \
     && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\

--- a/kafka/Dockerfile.ubi8
+++ b/kafka/Dockerfile.ubi8
@@ -71,7 +71,7 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && yum install -y confluent-kafka-${SCALA_VERSION}-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
     && yum clean all \
-    && rm -rf /tmp/* \
+    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
     && chown appuser:appuser -R /var/lib/${COMPONENT} /etc/${COMPONENT} \

--- a/server-connect-base/Dockerfile.deb8
+++ b/server-connect-base/Dockerfile.deb8
@@ -43,11 +43,10 @@ EXPOSE 8083
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get update \
+    && apt-get install -y apt-transport-https software-properties-common  \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
-    && apt-get install -y apt-transport-https \
+    && curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key | apt-key add - \
+    && apt-add-repository "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get update \
     && echo "===> Installing Schema Registry (for Avro jars) ..." \
     && apt-get install -y confluent-schema-registry=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
@@ -58,6 +57,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && echo "===> Installing Confluent Hub client ..." \
     && apt-get install -y confluent-hub-client=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..." \
+    && apt-add-repository --remove "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     echo "===> Setting up ${COMPONENT} dirs ..." \
     && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars \

--- a/server-connect-base/Dockerfile.ubi8
+++ b/server-connect-base/Dockerfile.ubi8
@@ -47,6 +47,21 @@ EXPOSE 8083
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent.dist] \n\
+name=Confluent repository (dist) \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 \n\
+\n\
+[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && echo "===> Installing Schema Registry (for Avro jars) ..." \
     && yum install -y confluent-schema-registry-${CONFLUENT_VERSION} \
     && echo "===> Installing Controlcenter for monitoring interceptors ..."\
@@ -57,7 +72,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && yum install -y confluent-hub-client-${CONFLUENT_VERSION} \
     && echo "===> Cleaning up ..."  \
     && yum clean all \
-    && rm -rf /tmp/* \
+    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs ..." \
     && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars /usr/logs \
     && chown appuser:appuser -R /etc/${COMPONENT} /usr/logs \

--- a/server-connect/Dockerfile.deb8
+++ b/server-connect/Dockerfile.deb8
@@ -40,13 +40,11 @@ ENV COMPONENT=kafka-connect
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get update \
+    && apt-get install -y apt-transport-https software-properties-common procps \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
+    && curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key | apt-key add - \
+    && apt-add-repository "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get update \
-    && apt-get install -y apt-transport-https \
-    && apt-get install -y procps \
     && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
     && apt-get install -y confluent-kafka-connect-jdbc=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     confluent-kafka-connect-elasticsearch=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
@@ -54,6 +52,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     confluent-kafka-connect-s3=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     confluent-kafka-connect-jms=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..." \
+    && apt-add-repository --remove "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*
 
 RUN echo "===> Installing GCS Sink Connector ..."

--- a/server-connect/Dockerfile.ubi8
+++ b/server-connect/Dockerfile.ubi8
@@ -44,6 +44,21 @@ ENV COMPONENT=kafka-connect
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent.dist] \n\
+name=Confluent repository (dist) \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 \n\
+\n\
+[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && echo "===> Installing JDBC, Elasticsearch and Hadoop connectors ..." \
     && yum install -y \
         confluent-kafka-connect-jdbc-${CONFLUENT_VERSION} \
@@ -53,7 +68,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
         confluent-kafka-connect-jms-${CONFLUENT_VERSION} \
     && echo "===> Cleaning up ..." \
     && yum clean all \
-    && rm -rf /tmp/*
+    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo
 
 RUN echo "===> Installing GCS Sink Connector ..." \
     && confluent-hub install confluentinc/kafka-connect-gcs:latest --no-prompt

--- a/server/Dockerfile.deb8
+++ b/server/Dockerfile.deb8
@@ -48,11 +48,10 @@ EXPOSE 9092
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get update \
+    && apt-get install -y apt-transport-https software-properties-common  \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
-    && apt-get install -y apt-transport-https \
+    && curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key | apt-key add - \
+    && apt-add-repository "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get update \
     && echo "===> installing ${COMPONENT}..." \
     && apt-get install -y confluent-server=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
@@ -61,6 +60,7 @@ RUN echo "===> Installing ${COMPONENT}..." \
     && echo "===> installing confluent-security ..." \
     && apt-get install -y confluent-security=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> clean up ..." \
+    && apt-add-repository --remove "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     && echo "===> Setting up ${COMPONENT} dirs..." \
     && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets\

--- a/server/Dockerfile.ubi8
+++ b/server/Dockerfile.ubi8
@@ -75,7 +75,7 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && yum install -y confluent-security-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
     && yum clean all \
-    && rm -rf /tmp/* \
+    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \
     && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /etc/${COMPONENT}/secrets \

--- a/zookeeper/Dockerfile.deb8
+++ b/zookeeper/Dockerfile.deb8
@@ -42,14 +42,14 @@ ENV COMPONENT=zookeeper
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get update \
+    && apt-get install -y apt-transport-https software-properties-common  \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
-    && apt-get install -y apt-transport-https \
+    && curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key | apt-key add - \
+    && apt-add-repository "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get update \
     && apt-get install -y confluent-kafka-${SCALA_VERSION}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> clean up ..." \
+    && apt-add-repository --remove "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \

--- a/zookeeper/Dockerfile.ubi8
+++ b/zookeeper/Dockerfile.ubi8
@@ -64,7 +64,7 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && yum install -y confluent-kafka-${SCALA_VERSION}-${CONFLUENT_VERSION} \
     && echo "===> clean up ..."  \
     && yum clean all \
-    && rm -rf /tmp/* \
+    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \
     && chmod -R ag+w /etc/kafka /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \


### PR DESCRIPTION
Couple of changes:
* Remove confluent's repo config. Confluent's images don't need to be able to update to the next CP release (Customers should be consuming the next versioned docker release)
* Removed the AllowUnauthenticated piece: In practice, we always import the public key for GPG automation validation.
