### PR TITLE
Disabled concurrent jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,4 +16,5 @@ dockerfile {
     cron = '' // Disable the cron because this job requires parameters
     cpImages = true
     osTypes = ['deb8', 'ubi8']
+    disableConcurrentBuilds = true
 }


### PR DESCRIPTION
Capping in branches 5.4.x through 6.0.x the number of concurrent Jenkins jobs running down to just 2 (one running, all others queued) in order to reduce the impact of releases has on Jenkins (To cap the “Jenkins Build Storm” after releases are finalized and bumped to the next version every quarter). This change will save a lot of Jenkins build resources.