### PR TITLE
fix: Ownership of appuser directories.

### DIFF
--- a/zookeeper/Dockerfile.ubi8
+++ b/zookeeper/Dockerfile.ubi8
@@ -68,7 +68,7 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \
     && chmod -R g+w /etc/kafka /var/lib/${COMPONENT}/data /var/lib/${COMPONENT}/log /etc/${COMPONENT}/secrets \
-    && chown -R appuser:appuser /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper /etc/${COMPONENT}/secrets
+    && chown -R appuser:appuser /etc/kafka /var/log/kafka /var/log/confluent /var/lib/kafka /var/lib/zookeeper /etc/${COMPONENT}/secrets
 
 VOLUME ["/var/lib/${COMPONENT}/data", "/var/lib/${COMPONENT}/log", "/etc/${COMPONENT}/secrets"]
 


### PR DESCRIPTION
After #116 was merged in, the UBI images failed to start:

```
% docker run -e ZOOKEEPER_CLIENT_PORT=32181 -e ZOOKEEPER_TICK_TIME=2000 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-zookeeper:5.4.x-latest-ubi8
===> User
uid=1000(appuser) gid=1000(appuser) groups=1000(appuser)
===> Configuring ...
Command [/usr/local/bin/dub path /etc/kafka/ writable] FAILED !
```

So thats what this change is for. I've reviewed all other instances of `dub path * writable` in this repo, and no other changes were required.