### PR TITLE
fix: Require either ZOOKEEPER_CLIENT_PORT or ZOOKEEPER_SECURE_CLIENT_PORT

### DIFF
--- a/zookeeper/include/etc/confluent/docker/configure
+++ b/zookeeper/include/etc/confluent/docker/configure
@@ -16,7 +16,7 @@
 
 . /etc/confluent/docker/bash-config
 
-dub ensure ZOOKEEPER_CLIENT_PORT
+dub ensure-atleast-one ZOOKEEPER_CLIENT_PORT ZOOKEEPER_SECURE_CLIENT_PORT
 
 dub path /etc/kafka/ writable
 

--- a/zookeeper/test/test_zookeeper.py
+++ b/zookeeper/test/test_zookeeper.py
@@ -54,7 +54,7 @@ class ConfigTest(unittest.TestCase):
         assert "PASS" in output
 
     def test_required_config_failure(self):
-        self.assertTrue("ZOOKEEPER_CLIENT_PORT is required." in self.cluster.service_logs("failing-config", stopped=True))
+        self.assertTrue("one of (ZOOKEEPER_CLIENT_PORT,ZOOKEEPER_SECURE_CLIENT_PORT) is required." in self.cluster.service_logs("failing-config", stopped=True))
         self.assertTrue("ZOOKEEPER_SERVER_ID is required." in self.cluster.service_logs("failing-config-server-id", stopped=True))
 
     def test_default_config(self):


### PR DESCRIPTION
Fixes #92 where Zookeeper wouldn't start if you only specify `ZOOKEEPER_SECURE_CLIENT_PORT` but not `ZOOKEEPER_CLIENT_PORT`.

Unfortunately I couldn't get the test suite running by myself. Would be great if someone could do this before merging.