### PR TITLE
update log4j.appender.stdout.layout.ConversionPattern as per KIP-721

### DIFF
--- a/kafka-connect-base/include/etc/confluent/docker/log4j.properties.template
+++ b/kafka-connect-base/include/etc/confluent/docker/log4j.properties.template
@@ -3,7 +3,7 @@ log4j.rootLogger={{ env["CONNECT_LOG4J_ROOT_LOGLEVEL"] | default('INFO') }}, std
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern ={{ env["CONNECT_LOG4J_APPENDER_STDOUT_LAYOUT_CONVERSIONPATTERN"] | default('[%d] %p %m (%c)%n') }}
+log4j.appender.stdout.layout.ConversionPattern ={{ env["CONNECT_LOG4J_APPENDER_STDOUT_LAYOUT_CONVERSIONPATTERN"] | default('[%d] %p %X{connector.context}%m (%c:%L)%n') }}
 
 
 {% set default_loggers = {

--- a/server-connect-base/include/etc/confluent/docker/log4j.properties.template
+++ b/server-connect-base/include/etc/confluent/docker/log4j.properties.template
@@ -3,7 +3,7 @@ log4j.rootLogger={{ env["CONNECT_LOG4J_ROOT_LOGLEVEL"] | default('INFO') }}, std
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern ={{ env["CONNECT_LOG4J_APPENDER_STDOUT_LAYOUT_CONVERSIONPATTERN"] | default('[%d] %p %m (%c)%n') }}
+log4j.appender.stdout.layout.ConversionPattern ={{ env["CONNECT_LOG4J_APPENDER_STDOUT_LAYOUT_CONVERSIONPATTERN"] | default('[%d] %p %X{connector.context}%m (%c:%L)%n') }}
 
 
 {% set default_loggers = {


### PR DESCRIPTION
[KIP-721](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=177047379) updated the log4j.appender.stdout.layout.ConversionPattern with the connector contexts to the Connect worker's logs. This change was missing in the log4j.propeties.template file used to generate the log4j.properties file in the connect docker images. 

This PR updated the log4j.appender.stdout.layout.ConversionPattern to use the connector contexts by default. 