### PR TITLE
remove unnecessary package install command

### DIFF
--- a/server-connect-base/Dockerfile.ubi8
+++ b/server-connect-base/Dockerfile.ubi8
@@ -66,8 +66,6 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && yum install -y confluent-schema-registry-${CONFLUENT_VERSION} \
     && echo "===> Installing Controlcenter for monitoring interceptors ..."\
     && yum install -y confluent-control-center-${CONFLUENT_VERSION} \
-    && echo "===> Installing Confluent security plugins ..." \
-    && yum install -y confluent-security-${CONFLUENT_VERSION} \
     && echo "===> Installing Confluent Hub client ..." \
     && yum install -y confluent-hub-client-${CONFLUENT_VERSION} \
     && echo "===> Cleaning up ..."  \


### PR DESCRIPTION
While reviewing container hierarchy for the ongoing SBOM work I have noticed that cp-server-connect-base image that is based on cp-server has a redundant commands for installing confluent-security package.
Package installed here in cp-server:
https://github.com/confluentinc/kafka-images/blob/5.5.x/server/Dockerfile.ubi8#L74

cp-server-connect-base is based on cp-server:
https://github.com/confluentinc/kafka-images/blob/5.5.x/server-connect-base/Dockerfile.ubi8#L20

This change should have no functional effect and it's purely cosmetic cleanup.
duplicate of https://github.com/confluentinc/kafka-images/pull/198 this time merging to 5.5.x instead of master