### PR TITLE
Exclude telemetry reporter during kafka-connect property generation

### DIFF
--- a/kafka-connect-base/include/etc/confluent/docker/kafka-connect.properties.template
+++ b/kafka-connect-base/include/etc/confluent/docker/kafka-connect.properties.template
@@ -1,4 +1,6 @@
-{% set connect_props = env_to_props('CONNECT_', '') -%}
+{% set excluded_props = ['CONNECT_METRIC_REPORTERS']
+
+{% set connect_props = env_to_props('CONNECT_', '', exclude=excluded_props) -%}
 {% for name, value in connect_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}


### PR DESCRIPTION
Context: https://confluent.slack.com/archives/C04F9R1AP2R/p1674810230472559

Kafka connect fails to start up when telemetry reporter is set, kafka-connect does not need telemetry reporter so exclude `CONNECT_METRIC_REPORTERS` from the list of properties during property generation.