### PR TITLE
Bump up the version of confluent-local pom

### DIFF
--- a/local/pom.xml
+++ b/local/pom.xml
@@ -19,7 +19,7 @@
    <parent>
       <groupId>io.confluent.kafka-images</groupId>
       <artifactId>kafka-images-parent</artifactId>
-      <version>7.4.1-0</version>
+      <version>7.5.0-0</version>
    </parent>
    <groupId>io.confluent.kafka-images</groupId>
    <artifactId>confluent-local</artifactId>


### PR DESCRIPTION
The `confluent-local` [PR](https://github.com/confluentinc/kafka-images/pull/211) was merged in the branch `7.4.x`
We did [pint merge](https://jenkins.confluent.io/job/tools-autotasks/job/tools-autotasks/job/apply-pint-merge/2556/console) to the master.

This PR updates the version in the `pom.xml` of the `local` module after the pint merge