### PR TITLE
Gracefully shutdown a kafka broker

### DIFF
--- a/kafka/include/etc/confluent/docker/run
+++ b/kafka/include/etc/confluent/docker/run
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+trap '/usr/bin/kafka-server-stop' EXIT
+
 . /etc/confluent/docker/bash-config
 
 # Set environment values if they exist as arguments


### PR DESCRIPTION
If I stop a container based on the `confluent/cp-kafka` image with `CTRL + C` and start my docker compose setup again I see the following error message:

```java
ERROR Exiting Kafka due to fatal exception during startup. (kafka.Kafka$)
org.apache.zookeeper.KeeperException$NodeExistsException: KeeperErrorCode = NodeExists
    at org.apache.zookeeper.KeeperException.create(KeeperException.java:126)
    at kafka.zk.KafkaZkClient$CheckedEphemeral.getAfterNodeExists(KafkaZkClient.scala:2185)
    at kafka.zk.KafkaZkClient$CheckedEphemeral.create(KafkaZkClient.scala:2123)
    at kafka.zk.KafkaZkClient.checkedEphemeralCreate(KafkaZkClient.scala:2090)
    at kafka.zk.KafkaZkClient.registerBroker(KafkaZkClient.scala:102)
    at kafka.server.KafkaServer.startup(KafkaServer.scala:355)
    at kafka.Kafka$.main(Kafka.scala:115)
    at kafka.Kafka.main(Kafka.scala)
```
which indicates that the kafka broker was not stopped properly. Executing the `kafka-server-stop` command at exit eliminates this problem.