### PR TITLE
OBSDATA-3754: Add BCFIPS JARs to cp-zookeeper

### DIFF
--- a/zookeeper/pom.xml
+++ b/zookeeper/pom.xml
@@ -41,6 +41,16 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bc-fips</artifactId>
+            <version>1.0.2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bctls-fips</artifactId>
+            <version>1.0.18</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
We need Zookeeper to be FIPS Compliant. This requires it to have necessary jars related to BouncyCastle Security Provider. This PR adds those JARs

These JARs won't be used until we provide a custom Java.security file to use BouncyCastle Security Provider. The Observability team uses this to run the zookeeper in the FIPS mode. 