### PR TITLE
[KMETA-1541] Update configure to set up SSL for kraft controllers

### DIFF
--- a/server/include/etc/confluent/docker/configure
+++ b/server/include/etc/confluent/docker/configure
@@ -23,6 +23,7 @@ if [[ -n "${KAFKA_PROCESS_ROLES-}" ]]
 then
   echo "Running in KRaft mode..."
   dub ensure CLUSTER_ID
+  dub ensure KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
   if [[ $KAFKA_PROCESS_ROLES == "controller" ]]
   then
     if [[ -n "${KAFKA_ADVERTISED_LISTENERS-}" ]]
@@ -84,8 +85,11 @@ then
   exit 1
 fi
 
-# Set if ADVERTISED_LISTENERS has SSL:// or SASL_SSL:// endpoints.
-if [[ -n "${KAFKA_ADVERTISED_LISTENERS-}" ]] && [[ $KAFKA_ADVERTISED_LISTENERS == *"SSL://"* ]]
+# Set various SSL env vars. 
+# We do this in KRaft mode if KAFKA_LISTENER_SECURITY_PROTOCOL_MAP has CONTROLLER:SSL or CONTROLLER:SASL_SSL
+# We do this in ZK mode if ADVERTISED_LISTENERS has SSL:// or SASL_SSL:// endpoints
+if ( [[ -n "${KAFKA_PROCESS_ROLES-}" ]] && [[ $KAFKA_LISTENER_SECURITY_PROTOCOL_MAP =~ CONTROLLER:(SSL|SASL_SSL) ]] ) || \
+   ( [[ -n "${KAFKA_ADVERTISED_LISTENERS-}" ]] && [[ $KAFKA_ADVERTISED_LISTENERS == *"SSL://"* ]] )
 then
   echo "SSL is enabled."
 

--- a/server/include/etc/confluent/docker/configure
+++ b/server/include/etc/confluent/docker/configure
@@ -87,8 +87,8 @@ fi
 # Set various SSL env vars. 
 # We do this in KRaft mode if KAFKA_LISTENER_SECURITY_PROTOCOL_MAP has CONTROLLER:SSL or CONTROLLER:SASL_SSL
 # We do this in ZK mode if ADVERTISED_LISTENERS has SSL:// or SASL_SSL:// endpoints
-if ( [[ -n "${KAFKA_PROCESS_ROLES-}" ]] && [[ $KAFKA_LISTENER_SECURITY_PROTOCOL_MAP =~ CONTROLLER:(SSL|SASL_SSL) ]] ) || \
-   ( [[ $KAFKA_ADVERTISED_LISTENERS == *"SSL://"* ]] )
+if ( [[ -n "${KAFKA_PROCESS_ROLES-}" ]] && [[ -n "${KAFKA_LISTENER_SECURITY_PROTOCOL_MAP-}" ]] && [[ $KAFKA_LISTENER_SECURITY_PROTOCOL_MAP =~ CONTROLLER:(SSL|SASL_SSL) ]] ) || \
+   ( [[ -n "${KAFKA_ADVERTISED_LISTENERS-}" ]] && [[ $KAFKA_ADVERTISED_LISTENERS == *"SSL://"* ]] )
 then
   echo "SSL is enabled."
 

--- a/server/include/etc/confluent/docker/configure
+++ b/server/include/etc/confluent/docker/configure
@@ -23,7 +23,6 @@ if [[ -n "${KAFKA_PROCESS_ROLES-}" ]]
 then
   echo "Running in KRaft mode..."
   dub ensure CLUSTER_ID
-  dub ensure KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
   if [[ $KAFKA_PROCESS_ROLES == "controller" ]]
   then
     if [[ -n "${KAFKA_ADVERTISED_LISTENERS-}" ]]
@@ -89,7 +88,7 @@ fi
 # We do this in KRaft mode if KAFKA_LISTENER_SECURITY_PROTOCOL_MAP has CONTROLLER:SSL or CONTROLLER:SASL_SSL
 # We do this in ZK mode if ADVERTISED_LISTENERS has SSL:// or SASL_SSL:// endpoints
 if ( [[ -n "${KAFKA_PROCESS_ROLES-}" ]] && [[ $KAFKA_LISTENER_SECURITY_PROTOCOL_MAP =~ CONTROLLER:(SSL|SASL_SSL) ]] ) || \
-   ( [[ -n "${KAFKA_ADVERTISED_LISTENERS-}" ]] && [[ $KAFKA_ADVERTISED_LISTENERS == *"SSL://"* ]] )
+   ( [[ $KAFKA_ADVERTISED_LISTENERS == *"SSL://"* ]] )
 then
   echo "SSL is enabled."
 


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/KMETA-1541

We only assign various SSL configs if `KAFKA_ADVERTISED_LISTENERS` indicates SSL is enabled, which doesn’t work when in KRaft controller-only mode (env var is NOT set in that case). We could check if `KAFKA_LISTENER_SECURITY_PROTOCOL_MAP` contains `CONTROLLER:SSL` or `CONTROLLER:SASL_SSL` in the KRaft case.