### PR TITLE
[MINOR] Disable build_arm in 6.2.x

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -23,7 +23,7 @@ semaphore:
   ]
   maven_phase: 'package'
   maven_skip_deploy: true
-  build_arm: true
+  build_arm: false
   os_types: ['ubi8']
   nano_version: true
   use_packages: true


### PR DESCRIPTION
arm64 docker builds are enabled from 7.0.x version onwards.