### PR TITLE
add confluent-local to service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -17,6 +17,7 @@ semaphore:
     'confluentinc/cp-kafka-connect-base',
     'confluentinc/cp-enterprise-kafka',
     'confluentinc/cp-kafka',
+    'confluentinc/confluent-local',
     'confluentinc/cp-server',
     'confluentinc/cp-zookeeper'
   ]


### PR DESCRIPTION
confluent-local is only introduced from 7.4.x. This patch adds confluent-local to docker repos.