### PR TITLE
Check KAFKA_LISTENER_SECURITY_PROTOCOL_MAP for SSL

### DIFF
--- a/kafka/include/etc/confluent/docker/configure
+++ b/kafka/include/etc/confluent/docker/configure
@@ -84,7 +84,9 @@ then
 fi
 
 # Set if ADVERTISED_LISTENERS has SSL:// or SASL_SSL:// endpoints.
-if [[ -n "${KAFKA_ADVERTISED_LISTENERS-}" ]] && [[ $KAFKA_ADVERTISED_LISTENERS == *"SSL://"* ]]
+# Or if the LISTENER_SECURITY_PROTOCOL_MAP includes SSL
+if ([[ -n "${KAFKA_ADVERTISED_LISTENERS-}" ]] && [[ $KAFKA_ADVERTISED_LISTENERS == *"SSL://"* ]]) ||
+  ([[ -n "${KAFKA_LISTENER_SECURITY_PROTOCOL_MAP-}" ]] && [[ $KAFKA_LISTENER_SECURITY_PROTOCOL_MAP == *":SSL"* ]])
 then
   echo "SSL is enabled."
 


### PR DESCRIPTION
The current approach adds SSL configuration if the advertised listeners includes the string `SSL://`.

But in a configuration such as

```
KAFKA_ADVERTISED_LISTENERS: CLIENTS://mykafka.host:9093
KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CLIENTS:SSL
```

The ssl configuration is not added, even though the protocol `CLIENTS` does map to `SSL`

Tweaking this configuration script so that it looks in both `KAFKA_ADVERTISED_LISTENERS` and `KAFKA_LISTENER_SECURITY_PROTOCOL_MAP` for usage of SSL.