### PR TITLE
Fix ctrl-c to stop confluent local docker container (#18)

### DIFF
--- a/local/include/etc/confluent/docker/launch
+++ b/local/include/etc/confluent/docker/launch
@@ -44,6 +44,17 @@ echo "===> Launching kafka-rest ... "
 kafka-rest-start /etc/kafka-rest/kafka-rest.properties & # your second application
 P2=$! # capture PID of the process
 
+# Function to handle cleanup
+cleanup() {
+  echo "Terminating processes..."
+  kill $P1 $P2
+  wait $P1 $P2 2>/dev/null
+  exit 1
+}
+
+# Trap SIGINT (Ctrl+C) and call cleanup
+trap cleanup SIGINT
+
 # Wait for either of these 2 process to exit
 wait -n $P1 $P2
 # Exit with status of process that exited first


### PR DESCRIPTION
- Confluent Local docker container once started doesn't get terminated or stopped on pressing Ctrl+C
- Added function to handle Ctrl+C sigint and terminate the processes

Tested by building and running docker image locally -
Image 1 (Ctrl-C not working) -
`docker run 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/confluentinc/confluent-local:7.4.x-latest-ubi8`

<img width="1728" alt="Screenshot 2024-10-24 at 9 53 16 AM" src="https://github.com/user-attachments/assets/9682f5a4-4057-47f8-92fc-1fbf10585d58">


Image 2 (Ctrl-C issue fixed) -
`docker run -P test-cflt-local`

<img width="1728" alt="Screenshot 2024-10-24 at 9 55 19 AM" src="https://github.com/user-attachments/assets/568f73c4-8188-427f-933d-d53321f9ac1a">
