### PR TITLE
feat: Add CONNECT_PROPERTIES_DIR environment variable support

### DIFF
--- a/kafka-connect-base/include/etc/confluent/docker/configure
+++ b/kafka-connect-base/include/etc/confluent/docker/configure
@@ -49,9 +49,19 @@ then
   dub ensure CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL
 fi
 
-dub path /etc/"${COMPONENT}"/ writable
+# Set default value for CONNECT_PROPERTIES_DIR if not provided
+export CONNECT_PROPERTIES_DIR=${CONNECT_PROPERTIES_DIR:-/etc/${COMPONENT}/}
 
-dub template "/etc/confluent/docker/${COMPONENT}.properties.template" "/etc/${COMPONENT}/${COMPONENT}.properties"
+# Ensure the properties directory exists and is writable
+dub path "${CONNECT_PROPERTIES_DIR}" writable
 
-# The connect-distributed script expects the log4j config at /etc/kafka/connect-log4j.properties.
-dub template "/etc/confluent/docker/log4j.properties.template" "/etc/kafka/connect-log4j.properties"
+dub template "/etc/confluent/docker/${COMPONENT}.properties.template" "${CONNECT_PROPERTIES_DIR}/${COMPONENT}.properties"
+
+# Set KAFKA_LOG4J_OPTS if CONNECT_PROPERTIES_DIR is set
+if [ -n "$CONNECT_PROPERTIES_DIR" ]; then
+  export KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=${CONNECT_PROPERTIES_DIR}/connect-log4j.properties"
+  dub template "/etc/confluent/docker/log4j.properties.template" "${CONNECT_PROPERTIES_DIR}/connect-log4j.properties"
+else
+  # The connect-distributed script expects the log4j config at /etc/kafka/connect-log4j.properties.
+  dub template "/etc/confluent/docker/log4j.properties.template" "/etc/kafka/connect-log4j.properties"
+fi

--- a/kafka-connect-base/include/etc/confluent/docker/launch
+++ b/kafka-connect-base/include/etc/confluent/docker/launch
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Set default value for CONNECT_PROPERTIES_DIR if not provided
+export CONNECT_PROPERTIES_DIR=${CONNECT_PROPERTIES_DIR:-/etc/${COMPONENT}/}
+
 
 # Override this section from the script to include the com.sun.management.jmxremote.rmi.port property.
 if [ -z "$KAFKA_JMX_OPTS" ]; then
@@ -41,4 +44,4 @@ echo "===> Launching ${COMPONENT} ... "
 if [ -z "$CLASSPATH" ]; then
     export CLASSPATH="/etc/kafka-connect/jars/*"
 fi
-exec connect-distributed /etc/"${COMPONENT}"/"${COMPONENT}".properties
+exec connect-distributed "${CONNECT_PROPERTIES_DIR}/${COMPONENT}.properties"


### PR DESCRIPTION
- Add CONNECT_PROPERTIES_DIR environment variable to specify custom directory for properties files

- Set default value to /etc/${COMPONENT}/

- Update configure script to use CONNECT_PROPERTIES_DIR for property file generation

- Update launch script to use CONNECT_PROPERTIES_DIR for loading properties