### PR TITLE
remove undefined variable in template

### DIFF
--- a/kafka/include/etc/confluent/docker/kafka.properties.template
+++ b/kafka/include/etc/confluent/docker/kafka.properties.template
@@ -15,12 +15,6 @@
 {{name}}={{value}}
 {% endfor -%}
 
-{% for k, property in other_props.items() -%}
-{% if env.get(k) != None -%}
-{{property}}={{env[k]}}
-{% endif -%}
-{% endfor -%}
-
 {% set confluent_support_props = env_to_props('CONFLUENT_SUPPORT_', 'confluent.support.') -%}
 {% for name, value in confluent_support_props.items() -%}
 {{name}}={{value}}

--- a/server/include/etc/confluent/docker/kafka.properties.template
+++ b/server/include/etc/confluent/docker/kafka.properties.template
@@ -15,12 +15,6 @@
 {{name}}={{value}}
 {% endfor -%}
 
-{% for k, property in other_props.items() -%}
-{% if env.get(k) != None -%}
-{{property}}={{env[k]}}
-{% endif -%}
-{% endfor -%}
-
 {% set confluent_support_props = env_to_props('CONFLUENT_SUPPORT_', 'confluent.support.') -%}
 {% for name, value in confluent_support_props.items() -%}
 {{name}}={{value}}


### PR DESCRIPTION
With recent changes done to remove zookeeper from kafka-images, `other_props` was variable definition was deleted from template file [here](https://github.com/confluentinc/kafka-images/commit/dbae484c01c4c7b262325bfd263e7f0859e2dd59#diff-50266ac00cfedb6b06dd955cedffd417603555c2e9da4241147c600c51d8387eL15). But not all usage of that variable were removed. 
This is leading to build failure for ksql-images [here](https://semaphore.ci.confluent.io/workflows/f49cb800-c2b4-400a-a6be-a13c01f7552f?pipeline_id=1508c16e-9ef8-48f7-9a09-d5ea22d16e63) as cp-server is used for testing. 