### PR TITLE
CPBR-2168 | Docker refresh for cp-kafka-connect image reduction

### DIFF
--- a/kafka-connect-base/Dockerfile.ubi9
+++ b/kafka-connect-base/Dockerfile.ubi9
@@ -64,9 +64,9 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && microdnf clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs ..." \
-    && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars /usr/logs /usr/share/confluent-hub-components \
-    && chown appuser:root -R /etc/kafka /etc/${COMPONENT} /etc/schema-registry /usr/logs /usr/share/confluent-hub-components \
-    && chmod -R ug+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars /etc/schema-registry /usr/share/confluent-hub-components\
+    && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars /usr/share/confluent-hub-components \
+    && chown appuser:root -R /etc/kafka /etc/${COMPONENT} /usr/logs /etc/schema-registry /usr/share/confluent-hub-components \
+    && chmod -R ug+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars /etc/schema-registry /usr/share/confluent-hub-components \
     && cd /usr/share/java \
     && package_dedupe $(pwd)
 

--- a/kafka-connect-base/Dockerfile.ubi9
+++ b/kafka-connect-base/Dockerfile.ubi9
@@ -57,16 +57,18 @@ gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && echo "===> Installing Schema Registry (for Avro jars) ..." \
-    && yum install -y confluent-schema-registry-${CONFLUENT_VERSION} \
-    && echo "===> Installing Confluent Hub client ..."\
-    && yum install -y confluent-hub-client-${CONFLUENT_VERSION} \
-    && echo "===> Cleaning up ..." \
-    && yum clean all \
+    && microdnf install -y confluent-schema-registry-${CONFLUENT_VERSION} \
+    && echo "===> Installing Confluent Hub client ..." \
+    && microdnf install -y confluent-hub-client-${CONFLUENT_VERSION} \
+    && echo "===> Cleaning up ..."  \
+    && microdnf clean all \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs ..." \
-    && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars /usr/share/confluent-hub-components \
-    && chown appuser:root -R /etc/kafka /etc/${COMPONENT} /usr/logs /etc/schema-registry /usr/share/confluent-hub-components \
-    && chmod -R ug+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars /etc/schema-registry /usr/share/confluent-hub-components
+    && mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars /usr/logs /usr/share/confluent-hub-components \
+    && chown appuser:root -R /etc/kafka /etc/${COMPONENT} /etc/schema-registry /usr/logs /usr/share/confluent-hub-components \
+    && chmod -R ug+w /etc/${COMPONENT} /etc/${COMPONENT}/secrets /etc/${COMPONENT}/jars /etc/schema-registry /usr/share/confluent-hub-components\
+    && cd /usr/share/java \
+    && package_dedupe $(pwd)
 
 ENV CONNECT_PLUGIN_PATH=/usr/share/java/,/usr/share/confluent-hub-components/
 

--- a/kafka-connect-base/include/etc/confluent/docker/configure
+++ b/kafka-connect-base/include/etc/confluent/docker/configure
@@ -16,16 +16,16 @@
 
 . /etc/confluent/docker/bash-config
 
-dub ensure CONNECT_BOOTSTRAP_SERVERS
-dub ensure CONNECT_GROUP_ID
-dub ensure CONNECT_CONFIG_STORAGE_TOPIC
-dub ensure CONNECT_OFFSET_STORAGE_TOPIC
-dub ensure CONNECT_STATUS_STORAGE_TOPIC
-dub ensure CONNECT_KEY_CONVERTER
-dub ensure CONNECT_VALUE_CONVERTER
+ub ensure CONNECT_BOOTSTRAP_SERVERS
+ub ensure CONNECT_GROUP_ID
+ub ensure CONNECT_CONFIG_STORAGE_TOPIC
+ub ensure CONNECT_OFFSET_STORAGE_TOPIC
+ub ensure CONNECT_STATUS_STORAGE_TOPIC
+ub ensure CONNECT_KEY_CONVERTER
+ub ensure CONNECT_VALUE_CONVERTER
 # This is required to avoid config bugs. You should set this to a value that is
 # resolvable by all containers.
-dub ensure CONNECT_REST_ADVERTISED_HOST_NAME
+ub ensure CONNECT_REST_ADVERTISED_HOST_NAME
 
 # Default to 8083, which matches the mesos-overrides. This is here in case we extend the containers to remove the mesos overrides.
 if [ -z "$CONNECT_REST_PORT" ]; then
@@ -41,17 +41,17 @@ fi
 
 if [[ $CONNECT_KEY_CONVERTER == "io.confluent.connect.avro.AvroConverter" ]]
 then
-  dub ensure CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL
+  ub ensure CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL
 fi
 
 if [[ $CONNECT_VALUE_CONVERTER == "io.confluent.connect.avro.AvroConverter" ]]
 then
-  dub ensure CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL
+  ub ensure CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL
 fi
 
-dub path /etc/"${COMPONENT}"/ writable
+ub path /etc/"${COMPONENT}"/ writable
 
-dub template "/etc/confluent/docker/${COMPONENT}.properties.template" "/etc/${COMPONENT}/${COMPONENT}.properties"
+ub render-template "/etc/confluent/docker/${COMPONENT}.properties.template" > /etc/${COMPONENT}/${COMPONENT}.properties
 
 # The connect-distributed script expects the log4j2 config at /etc/kafka/connect-log4j2.yaml.
-dub template "/etc/confluent/docker/log4j2.yaml.template" "/etc/kafka/connect-log4j2.yaml"
+ub render-template "/etc/confluent/docker/log4j2.yaml.template" > /etc/kafka/connect-log4j2.yaml

--- a/kafka-connect-base/include/etc/confluent/docker/ensure
+++ b/kafka-connect-base/include/etc/confluent/docker/ensure
@@ -21,14 +21,14 @@ echo "===> Check if Kafka is healthy ..."
 if [[ -n "${CONNECT_SECURITY_PROTOCOL-}" ]] && [[ $CONNECT_SECURITY_PROTOCOL != "PLAINTEXT" ]]
 then
 
-    cub kafka-ready \
+    ub kafka-ready \
         "${CONNECT_CUB_KAFKA_MIN_BROKERS:-1}" \
         "${CONNECT_CUB_KAFKA_TIMEOUT:-40}" \
         -b "$CONNECT_BOOTSTRAP_SERVERS" \
         --config /etc/"${COMPONENT}"/kafka-connect.properties
 else
 
-    cub kafka-ready \
+    ub kafka-ready \
         "${CONNECT_CUB_KAFKA_MIN_BROKERS:-1}" \
         "${CONNECT_CUB_KAFKA_TIMEOUT:-40}" \
         -b "$CONNECT_BOOTSTRAP_SERVERS"

--- a/kafka-connect-base/include/etc/confluent/docker/kafka-connect.properties.template
+++ b/kafka-connect-base/include/etc/confluent/docker/kafka-connect.properties.template
@@ -1,6 +1,5 @@
-{% set excluded_props = ['CONNECT_METRIC_REPORTERS'] -%}
-
-{% set connect_props = env_to_props('CONNECT_', '', exclude=excluded_props) -%}
-{% for name, value in connect_props.items() -%}
-{{name}}={{value}}
-{% endfor -%}
+{{- $excluded_props := "CONNECT_METRIC_REPORTERS" -}}
+{{- $connect_props := envToProps "CONNECT_" "" nil nil $excluded_props -}}
+{{- range $k, $v := $connect_props }}
+{{ $k }}={{ $v }}
+{{- end }}

--- a/kafka-connect-base/include/etc/confluent/docker/kafka-connect.properties.template
+++ b/kafka-connect-base/include/etc/confluent/docker/kafka-connect.properties.template
@@ -1,4 +1,4 @@
-{{- $excluded_props := "CONNECT_METRIC_REPORTERS" -}}
+{{- $excluded_props := stringSlice "CONNECT_METRIC_REPORTERS" -}}
 {{- $connect_props := envToProps "CONNECT_" "" nil nil $excluded_props -}}
 {{- range $k, $v := $connect_props }}
 {{ $k }}={{ $v }}

--- a/kafka-connect-base/include/etc/confluent/docker/log4j2.yaml.template
+++ b/kafka-connect-base/include/etc/confluent/docker/log4j2.yaml.template
@@ -6,28 +6,19 @@ Configuration:
       name: STDOUT
       target: SYSTEM_OUT
       PatternLayout:
-        Pattern: "{{ env['CONNECT_LOG4J_APPENDER_STDOUT_LAYOUT_CONVERSIONPATTERN'] | default('[%d] %p %m (%c)%n') }}"
+        Pattern: "{{ getEnv "CONNECT_LOG4J_APPENDER_STDOUT_LAYOUT_CONVERSIONPATTERN" "[%d] %p %m (%c)%n" }}"
 
   Loggers:
     Root:
-      level: "{{ env['CONNECT_LOG4J_ROOT_LOGLEVEL'] | default('INFO') }}"
+      level: "{{ getEnv "CONNECT_LOG4J_ROOT_LOGLEVEL" "INFO" }}"
       AppenderRef:
         - ref: STDOUT
     Logger:
-{% set default_loggers = {
-	'org.reflections': 'ERROR'
-} -%}
-
-{% if env['CONNECT_LOG4J_LOGGERS'] %}
-# loggers from CONNECT_LOG4J_LOGGERS env variable
-{% set loggers = parse_log4j_loggers(env['CONNECT_LOG4J_LOGGERS']) %}
-{% else %}
-# default log levels
-{% set loggers = default_loggers %}
-{% endif %}
-{% for logger,loglevel in loggers.items() %}
-      - name: "{{ logger }}"
-        level: "{{ loglevel }}"
+{{- $defaultLoggers := splitToMapDefaults "," "org.reflections=ERROR" "" -}}
+{{- $loggers := parseLog4jLoggers (getEnv "CONNECT_LOG4J_LOGGERS" "") $defaultLoggers -}}
+{{- range $k, $v := $loggers }}
+      - name: "{{ $k }}"
+        level: "{{ $v }}"
         AppenderRef:
           - ref: STDOUT
-{% endfor %}
+{{- end }}

--- a/kafka-connect/Dockerfile.ubi9
+++ b/kafka-connect/Dockerfile.ubi9
@@ -45,7 +45,7 @@ USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && echo "===> Cleaning up ..." \
-    && yum clean all \
+    && microdnf clean all \
     && rm -rf /tmp/*
 
 USER appuser


### PR DESCRIPTION
This PR will have following changes:

Package dedupe script execution
Changed yum to microdnf
cub/dub changed to ub
---
Nightly image size: 1300 MB
Refreshed image size: 703 MB
---
For more detail and testing strategy: https://confluentinc.atlassian.net/browse/CPBR-2168