### PR TITLE
fix code artifact package path for cp-server-native

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -103,6 +103,7 @@ code_artifact:
     - maven-snapshots/maven/io.confluent.kafka-images/cp-server-connect-base
     - maven-snapshots/maven/io.confluent.kafka-images/cp-server-connect
     - maven-snapshots/maven/io.confluent.kafka-images/cp-server
+    - maven-snapshots/maven/io.confluent.kafka-images/cp-server-native
     - maven-snapshots/maven/io.confluent.kafka-images/confluent-local
     - maven-snapshots/maven/io.confluent.kafka-images/cp-kafka-connect-base
     - maven-snapshots/maven/io.confluent.kafka-images/cp-kafka-connect


### PR DESCRIPTION
cp-server-native docker image is correctly getting built and pushed to ECR https://semaphore.ci.confluent.io/workflows/2b2dec26-2d1a-4ec6-9d6b-aeeaee6fac27?pipeline_id=a74cb204-5ba7-4204-9cfb-077374ea388b

however, it fails during maven deploy with error -
https://semaphore.ci.confluent.io/jobs/da6934c9-7c53-4910-8276-1727da6ee591#L1321
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project cp-server-native: Failed to deploy artifacts: Could not transfer artifact io.confluent.kafka-images:cp-server-native:jar:8.0.1-37 from/to confluent-codeartifact-internal (https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/): status code: 403, reason phrase: Forbidden (403) -> [Help 1]
```

as per https://confluentinc.atlassian.net/wiki/spaces/ADP/pages/3324412526/Add+Code+Artifact package path needs to be defined in default branch, which is master in this case