### PR TITLE
Update promotion pipeline to include cp-server-native for 8.0.x

### DIFF
--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -280,6 +280,37 @@ blocks:
                   docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH
                   docker push $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH
               fi
+        - name: Promote confluentinc/cp-server-native ubi9 AMD
+          env_vars:
+            - name: DOCKER_IMAGE
+              value: confluentinc/cp-server-native
+          commands:
+            - export OS_TYPE="ubi9"
+            - export DOCKER_REPO="confluentinc/cp-server-native"
+            - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
+            - export INTERNAL_IMAGE_TAG="$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$AMD_ARCH"
+            - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG$AMD_ARCH"
+            - docker pull $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG
+            - docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$PROMOTED_TAG
+            - docker run --rm $DOCKER_REPO:$PROMOTED_TAG sh -c "grep staging /etc/yum.repos.d/confluent.repo || grep staging /etc/apt/sources.list" || export STAGING_CHECK_SUCCEED="true"
+            - if [[ ! "$STAGING_CHECK_SUCCEED" ]]; then echo "Detected there was a staging repo in image $DOCKER_REPO:$PROMOTED_TAG refusing to promote." && exit 1; fi
+            - docker push $DOCKER_REPO:$PROMOTED_TAG
+            - >-
+              if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
+                  export APPLY_TAG=$CONFLUENT_VERSION$AMD_ARCH
+                  docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$APPLY_TAG
+                  docker push $DOCKER_REPO:$APPLY_TAG
+                  export APPLIED="true"
+              fi
+            - >-
+              if [[ $UPDATE_LATEST_TAG == "True" ]]; then
+                  if [[ $APPLIED ]]; then
+                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest$AMD_ARCH
+                  docker push $DOCKER_REPO:latest$AMD_ARCH
+                  fi
+                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH
+                  docker push $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH
+              fi
   - name: Promote ARM
     dependencies: []
     task:
@@ -501,6 +532,37 @@ blocks:
                   docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
                   docker push $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
               fi
+        - name: Promote confluentinc/cp-server-native ubi9 ARM
+          env_vars:
+            - name: DOCKER_IMAGE
+              value: confluentinc/cp-server-native
+          commands:
+            - export OS_TYPE="ubi9"
+            - export DOCKER_REPO="confluentinc/cp-server-native"
+            - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
+            - export INTERNAL_IMAGE_TAG="$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$ARM_ARCH"
+            - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG$ARM_ARCH"
+            - docker pull $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG
+            - docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$PROMOTED_TAG
+            - docker run --rm $DOCKER_REPO:$PROMOTED_TAG sh -c "grep staging /etc/yum.repos.d/confluent.repo || grep staging /etc/apt/sources.list" || export STAGING_CHECK_SUCCEED="true"
+            - if [[ ! "$STAGING_CHECK_SUCCEED" ]]; then echo "Detected there was a staging repo in image $DOCKER_REPO:$PROMOTED_TAG refusing to promote." && exit 1; fi
+            - docker push $DOCKER_REPO:$PROMOTED_TAG
+            - >-
+              if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
+                  export APPLY_TAG=$CONFLUENT_VERSION$ARM_ARCH
+                  docker tag $DOCKER_PROD_REGISTRY$DOCKER_REPO:$INTERNAL_IMAGE_TAG $DOCKER_REPO:$APPLY_TAG
+                  docker push $DOCKER_REPO:$APPLY_TAG
+                  export APPLIED="true"
+              fi
+            - >-
+              if [[ $UPDATE_LATEST_TAG == "True" ]]; then
+                  if [[ $APPLIED ]]; then
+                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest$ARM_ARCH
+                  docker push $DOCKER_REPO:latest$ARM_ARCH
+                  fi
+                  docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
+                  docker push $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
+              fi
   - name: Create Manifest
     dependencies: ["Promote AMD", "Promote ARM"]
     task:
@@ -669,6 +731,32 @@ blocks:
             - export OS_TYPE="ubi9"
             - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
             - export DOCKER_REPO="confluentinc/cp-server"
+            - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG"
+            - docker manifest create $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:$PROMOTED_TAG$AMD_ARCH $DOCKER_REPO:$PROMOTED_TAG$ARM_ARCH
+            - docker manifest push $DOCKER_REPO:$PROMOTED_TAG
+            - >-
+              if [[ ! "$OS_TYPE" ]] || [[ "$OS_TYPE" =~ ubi* ]]; then
+                  docker manifest create $DOCKER_REPO:$CONFLUENT_VERSION $DOCKER_REPO:$CONFLUENT_VERSION$AMD_ARCH $DOCKER_REPO:$CONFLUENT_VERSION$ARM_ARCH
+                  docker manifest push $DOCKER_REPO:$CONFLUENT_VERSION
+                  export APPLIED="true"
+              fi
+            - >-
+              if [[ $UPDATE_LATEST_TAG == "True" ]]; then
+                  if [[ $APPLIED ]]; then
+                  docker manifest create $DOCKER_REPO:latest $DOCKER_REPO:latest$AMD_ARCH $DOCKER_REPO:latest$ARM_ARCH
+                  docker manifest push $DOCKER_REPO:latest
+                  fi
+                  docker manifest create $DOCKER_REPO:latest-$OS_TYPE $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
+                  docker manifest push $DOCKER_REPO:latest-$OS_TYPE
+              fi
+        - name: Create Manifest confluentinc/cp-server-native ubi9
+          env_vars:
+            - name: DOCKER_IMAGE
+              value: confluentinc/cp-server-native
+          commands:
+            - export OS_TYPE="ubi9"
+            - if [[ ! "$OS_TYPE" ]]; then export OS_TAG=""; elif [[ "$OS_TYPE" =~ $PROMOTE_OS_TYPE* ]]; then export OS_TAG="-$OS_TYPE"; fi
+            - export DOCKER_REPO="confluentinc/cp-server-native"
             - export PROMOTED_TAG="$PROMOTED_TAG_PREFIX$OS_TAG"
             - docker manifest create $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:$PROMOTED_TAG$AMD_ARCH $DOCKER_REPO:$PROMOTED_TAG$ARM_ARCH
             - docker manifest push $DOCKER_REPO:$PROMOTED_TAG


### PR DESCRIPTION
- As a first step, we plan to ship the cp-server-native image with the CP 8.0.1 release. We’ll gather feedback from this release before deciding whether to include it in all future major and minor CP releases.

- Accordingly, updated .semaphore/cp_dockerfile_promote.yml to add blocks for promoting the cp-server-native Docker image on DockerHub. For now, this change is only required in the 8.0.x branch.