### PR TITLE
Resolve log4j config issue with env variable overrides

### DIFF
--- a/kafka/include/etc/confluent/docker/log4j2.yaml.template
+++ b/kafka/include/etc/confluent/docker/log4j2.yaml.template
@@ -15,44 +15,20 @@ Configuration:
         - ref: STDOUT
 
     Logger:
-      - name: "kafka"
-        level: "INFO"
+{{- $defaultLoggersStr := printf "%s,%s,%s,%s,%s,%s,%s,%s" 
+    "kafka=INFO"
+    "kafka.network.RequestChannel$=WARN"
+    "kafka.producer.async.DefaultEventHandler=DEBUG"
+    "kafka.request.logger=WARN"
+    "kafka.controller=TRACE"
+    "kafka.log.LogCleaner=INFO"
+    "state.change.logger=TRACE"
+    "kafka.authorizer.logger=WARN" -}}
+{{- $defaultLoggers := splitToMapDefaults "," $defaultLoggersStr "" -}}
+{{- $loggers := parseLog4jLoggers (getEnv "KAFKA_LOG4J_LOGGERS" "") $defaultLoggers -}}
+{{- range $k, $v := $loggers }}
+      - name: "{{ $k }}"
+        level: "{{ $v }}"
         AppenderRef:
-          ref: STDOUT
-      - name: "kafka.network.RequestChannel$"
-        level: "WARN"
-        AppenderRef:
-          ref: STDOUT
-      - name: "kafka.producer.async.DefaultEventHandler"
-        level: "DEBUG"
-        AppenderRef:
-          ref: STDOUT
-      - name: "kafka.request.logger"
-        level: "WARN"
-        AppenderRef:
-          ref: STDOUT
-      - name: "kafka.controller"
-        level: "TRACE"
-        AppenderRef:
-          ref: STDOUT
-      - name: "kafka.log.LogCleaner"
-        level: "INFO"
-        AppenderRef:
-          ref: STDOUT
-      - name: "state.change.logger"
-        level: "TRACE"
-        AppenderRef:
-          ref: STDOUT
-      - name: "kafka.authorizer.logger"
-        level: "WARN"
-        AppenderRef:
-          ref: STDOUT
-{{- if getEnv "KAFKA_LOG4J_LOGGERS" "" -}}
-{{- $customLoggers := parseLog4jLoggers (getEnv "KAFKA_LOG4J_LOGGERS" "") -}}
-{{- range $logger, $loglevel := $customLoggers -}}
-      - name: "{{ $logger }}"
-        level: "{{ $loglevel }}"
-        AppenderRef:
-          ref: STDOUT
-{{- end -}}
-{{- end -}}
+          - ref: STDOUT
+{{- end }}

--- a/server/include/etc/confluent/docker/log4j2.yaml.template
+++ b/server/include/etc/confluent/docker/log4j2.yaml.template
@@ -15,44 +15,20 @@ Configuration:
         - ref: STDOUT
 
     Logger:
-      - name: "kafka"
-        level: "INFO"
+{{- $defaultLoggersStr := printf "%s,%s,%s,%s,%s,%s,%s,%s" 
+    "kafka=INFO"
+    "kafka.network.RequestChannel$=WARN"
+    "kafka.producer.async.DefaultEventHandler=DEBUG"
+    "kafka.request.logger=WARN"
+    "kafka.controller=TRACE"
+    "kafka.log.LogCleaner=INFO"
+    "state.change.logger=TRACE"
+    "kafka.authorizer.logger=WARN" -}}
+{{- $defaultLoggers := splitToMapDefaults "," $defaultLoggersStr "" -}}
+{{- $loggers := parseLog4jLoggers (getEnv "KAFKA_LOG4J_LOGGERS" "") $defaultLoggers -}}
+{{- range $k, $v := $loggers }}
+      - name: "{{ $k }}"
+        level: "{{ $v }}"
         AppenderRef:
-          ref: STDOUT
-      - name: "kafka.network.RequestChannel$"
-        level: "WARN"
-        AppenderRef:
-          ref: STDOUT
-      - name: "kafka.producer.async.DefaultEventHandler"
-        level: "DEBUG"
-        AppenderRef:
-          ref: STDOUT
-      - name: "kafka.request.logger"
-        level: "WARN"
-        AppenderRef:
-          ref: STDOUT
-      - name: "kafka.controller"
-        level: "TRACE"
-        AppenderRef:
-          ref: STDOUT
-      - name: "kafka.log.LogCleaner"
-        level: "INFO"
-        AppenderRef:
-          ref: STDOUT
-      - name: "state.change.logger"
-        level: "TRACE"
-        AppenderRef:
-          ref: STDOUT
-      - name: "kafka.authorizer.logger"
-        level: "WARN"
-        AppenderRef:
-          ref: STDOUT
-{{- if getEnv "KAFKA_LOG4J_LOGGERS" "" -}}
-{{- $customLoggers := parseLog4jLoggers (getEnv "KAFKA_LOG4J_LOGGERS" "") -}}
-{{- range $logger, $loglevel := $customLoggers -}}
-      - name: "{{ $logger }}"
-        level: "{{ $loglevel }}"
-        AppenderRef:
-          ref: STDOUT
-{{- end -}}
-{{- end -}}
+          - ref: STDOUT
+{{- end }}


### PR DESCRIPTION
This PR introduces an override option for log4j configuration via environment variables. Currently, when additional settings are passed through the KAFKA_LOG4J_LOGGER environment variable, they are appended to the default configuration instead of replacing it. This change ensures that the provided configuration can properly override the defaults.
Testing: This fix has been tested locally, all existing environment variables work identically with no behavioral changes. Logger deduplication, property generation, and YAML formatting produce valid configurations.