### PR TITLE
CPBR-3815: Enable s390x image builds

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -95,6 +95,9 @@ semaphore:
           options:
             - 'True'
             - 'False'    
+cp_dockerfile:
+  s390x_docker_repos: ['confluentinc/cp-server', 'confluentinc/cp-server-connect-base', 'confluentinc/cp-server-connect']
+  s390x_maven_modules: ['server', 'server-connect-base', 'server-connect']
 code_artifact:
   enable: true
   package_paths:


### PR DESCRIPTION
Adds the `cp_dockerfile` block to `service.yml` so `cp-server`, `cp-server-connect-base`, and `cp-server-connect` are built for s390x, matching `8.2.x` and `master`.

```yaml
cp_dockerfile:
  s390x_docker_repos: ['confluentinc/cp-server', 'confluentinc/cp-server-connect-base', 'confluentinc/cp-server-connect']
  s390x_maven_modules: ['server', 'server-connect-base', 'server-connect']
```

The s390x config landed on `8.2.x` and `master` under CPBR-3661 but never on `8.3.x` (cut from master just before the change merged; `-s ours` merges don't carry content).

This PR contains `service.yml` changes only; files under `.semaphore/` will be auto-updated by triggering the cc-service-bot workflow.