### PR TITLE
KMETA-3163: Add IS_DYNAMIC_QUORUM env var to control --no-initial-controllers

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -7,6 +7,12 @@ Docker image for deploying and running the Community Version of Kafka packaged w
 * [Notes on using the image](https://docs.confluent.io/platform/current/installation/docker/installation.html) 
 * [Configuration Reference](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#confluent-ak-configuration)
 
+### `IS_DYNAMIC_QUORUM`
+
+Optional boolean (`true` or `false`, defaults to `false`) that controls how the image formats the storage directory at container start. When set to `true`, the image passes `--no-initial-controllers` to `kafka-storage format`, so the node joins the existing controller quorum instead of writing its own initial voter set.
+
+**Only set `IS_DYNAMIC_QUORUM=true` after the cluster has completed migration to a dynamic controller quorum ([KIP-853](https://cwiki.apache.org/confluence/display/KAFKA/KIP-853%3A+KRaft+Controller+Membership+Changes)).** Until that migration is complete the quorum membership is still static (`controller.quorum.voters`), and formatting without an initial controller set produces a node that cannot join the quorum. Leave the variable unset or `false` on clusters that have not migrated.
+
 ## Resources
 
 * [Docker Quick Start for Apache Kafka using Confluent Platform](https://docs.confluent.io/platform/current/quickstart/ce-docker-quickstart.html#ce-docker-quickstart)

--- a/kafka/include/etc/confluent/docker/ensure
+++ b/kafka/include/etc/confluent/docker/ensure
@@ -23,7 +23,24 @@ ub path "$KAFKA_DATA_DIRS" writable
 # Required step: Format the storage directory with provided cluster ID unless it already exists.
 echo "===> Using provided cluster id $CLUSTER_ID ..."
 
-# A bit of a hack to not error out if the storage is already formatted.  Need storage-tool to support this
-result=$(kafka-storage format --cluster-id=$CLUSTER_ID -c /etc/kafka/kafka.properties 2>&1) || \
-    echo $result | grep -i "already formatted" || \
-    { echo $result && (exit 1) }
+# --ignore-formatted skips log directories that are already formatted instead of failing, so this is
+# safe to re-run on every start.
+format_args=(--cluster-id="$CLUSTER_ID" -c /etc/kafka/kafka.properties --ignore-formatted)
+
+# IS_DYNAMIC_QUORUM tells the storage tool that this cluster's controller quorum membership is
+# managed dynamically (KIP-853) rather than by a static controller.quorum.voters list.  Only set it
+# to true AFTER the cluster has completed the migration to a dynamic quorum; setting it on a cluster
+# that still uses a static voter set will format a node that cannot join the quorum.
+case "${IS_DYNAMIC_QUORUM:-false}" in
+    [Tt][Rr][Uu][Ee])
+        echo "===> IS_DYNAMIC_QUORUM is true, formatting without an initial controller set ..."
+        format_args+=(--no-initial-controllers)
+        ;;
+    [Ff][Aa][Ll][Ss][Ee]) ;;
+    *)
+        echo "IS_DYNAMIC_QUORUM must be true or false, got '$IS_DYNAMIC_QUORUM'"
+        exit 1
+        ;;
+esac
+
+kafka-storage format "${format_args[@]}"

--- a/local/README.md
+++ b/local/README.md
@@ -9,6 +9,12 @@ Confluent-Local image deploys Apache Kafka along with Confluent Community RestPr
 ## Using the image
 This Docker image starts with KRaft as the default mode. Check [here](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#confluent-enterprise-ak-configuration) to modify the default configurations. 
 
+### `IS_DYNAMIC_QUORUM`
+
+Optional boolean (`true` or `false`, defaults to `false`) that controls how the image formats the storage directory at container start. When set to `true`, the image passes `--no-initial-controllers` to `kafka-storage format`, so the node joins the existing controller quorum instead of writing its own initial voter set.
+
+**Only set `IS_DYNAMIC_QUORUM=true` after the cluster has completed migration to a dynamic controller quorum ([KIP-853](https://cwiki.apache.org/confluence/display/KAFKA/KIP-853%3A+KRaft+Controller+Membership+Changes)).** Until that migration is complete the quorum membership is still static (`controller.quorum.voters`), and formatting without an initial controller set produces a node that cannot join the quorum. Leave the variable unset or `false` on clusters that have not migrated.
+
 ## Resources
 
 [What is Apache Kafka?](https://developer.confluent.io/learn-kafka)

--- a/local/include/etc/confluent/docker/ensure
+++ b/local/include/etc/confluent/docker/ensure
@@ -25,8 +25,25 @@ if [[ -n "${KAFKA_PROCESS_ROLES-}" ]]
 then
     echo "===> Using provided cluster id $CLUSTER_ID ..."
 
-    # A bit of a hack to not error out if the storage is already formatted.  Need storage-tool to support this
-    result=$(kafka-storage format --cluster-id=$CLUSTER_ID -c /etc/kafka/kafka.properties 2>&1) || \
-        echo $result | grep -i "already formatted" || \
-        { echo $result && (exit 1) }
+    # --ignore-formatted skips log directories that are already formatted instead of failing, so this is
+    # safe to re-run on every start.
+    format_args=(--cluster-id="$CLUSTER_ID" -c /etc/kafka/kafka.properties --ignore-formatted)
+
+    # IS_DYNAMIC_QUORUM tells the storage tool that this cluster's controller quorum membership is
+    # managed dynamically (KIP-853) rather than by a static controller.quorum.voters list.  Only set
+    # it to true AFTER the cluster has completed the migration to a dynamic quorum; setting it on a
+    # cluster that still uses a static voter set will format a node that cannot join the quorum.
+    case "${IS_DYNAMIC_QUORUM:-false}" in
+        [Tt][Rr][Uu][Ee])
+            echo "===> IS_DYNAMIC_QUORUM is true, formatting without an initial controller set ..."
+            format_args+=(--no-initial-controllers)
+            ;;
+        [Ff][Aa][Ll][Ss][Ee]) ;;
+        *)
+            echo "IS_DYNAMIC_QUORUM must be true or false, got '$IS_DYNAMIC_QUORUM'"
+            exit 1
+            ;;
+    esac
+
+    kafka-storage format "${format_args[@]}"
 fi

--- a/server/README.md
+++ b/server/README.md
@@ -18,6 +18,12 @@ Confluent Server is a commercial component of Confluent Platform.
 * [Notes on using the image](https://docs.confluent.io/platform/current/installation/docker/installation.html) 
 * [Configuration Reference](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#confluent-enterprise-ak-configuration)
 
+### `IS_DYNAMIC_QUORUM`
+
+Optional boolean (`true` or `false`, defaults to `false`) that controls how the image formats the storage directory at container start. When set to `true`, the image passes `--no-initial-controllers` to `kafka-storage format`, so the node joins the existing controller quorum instead of writing its own initial voter set.
+
+**Only set `IS_DYNAMIC_QUORUM=true` after the cluster has completed migration to a dynamic controller quorum ([KIP-853](https://cwiki.apache.org/confluence/display/KAFKA/KIP-853%3A+KRaft+Controller+Membership+Changes)).** Until that migration is complete the quorum membership is still static (`controller.quorum.voters`), and formatting without an initial controller set produces a node that cannot join the quorum. Leave the variable unset or `false` on clusters that have not migrated.
+
 ## Resources
 
 * [Docker Quick Start for Apache Kafka using Confluent Platform](https://docs.confluent.io/platform/current/quickstart/ce-docker-quickstart.html#ce-docker-quickstart)

--- a/server/include/etc/confluent/docker/ensure
+++ b/server/include/etc/confluent/docker/ensure
@@ -23,7 +23,24 @@ ub path "$KAFKA_DATA_DIRS" writable
 # Required step: Format the storage directory with provided cluster ID unless it already exists.
 echo "===> Using provided cluster id $CLUSTER_ID ..."
 
-# A bit of a hack to not error out if the storage is already formatted.  Need storage-tool to support this
-result=$(kafka-storage format --cluster-id=$CLUSTER_ID -c /etc/kafka/kafka.properties 2>&1) || \
-    echo $result | grep -i "already formatted" || \
-    { echo $result && (exit 1) }
+# --ignore-formatted skips log directories that are already formatted instead of failing, so this is
+# safe to re-run on every start.
+format_args=(--cluster-id="$CLUSTER_ID" -c /etc/kafka/kafka.properties --ignore-formatted)
+
+# IS_DYNAMIC_QUORUM tells the storage tool that this cluster's controller quorum membership is
+# managed dynamically (KIP-853) rather than by a static controller.quorum.voters list.  Only set it
+# to true AFTER the cluster has completed the migration to a dynamic quorum; setting it on a cluster
+# that still uses a static voter set will format a node that cannot join the quorum.
+case "${IS_DYNAMIC_QUORUM:-false}" in
+    [Tt][Rr][Uu][Ee])
+        echo "===> IS_DYNAMIC_QUORUM is true, formatting without an initial controller set ..."
+        format_args+=(--no-initial-controllers)
+        ;;
+    [Ff][Aa][Ll][Ss][Ee]) ;;
+    *)
+        echo "IS_DYNAMIC_QUORUM must be true or false, got '$IS_DYNAMIC_QUORUM'"
+        exit 1
+        ;;
+esac
+
+kafka-storage format "${format_args[@]}"


### PR DESCRIPTION
## Summary

Reworks the `kafka-storage format` invocation in the `cp-kafka`, `cp-server`, and `confluent-local` `ensure` scripts, and adds a new `IS_DYNAMIC_QUORUM` environment variable.

### `--ignore-formatted` replaces the "already formatted" hack

The previous code captured the format output, and on failure grepped for the string `already formatted` to decide whether to swallow the error:

```bash
result=$(kafka-storage format --cluster-id=$CLUSTER_ID -c /etc/kafka/kafka.properties 2>&1) || \
    echo $result | grep -i "already formatted" || \
    { echo $result && (exit 1) }
```

The storage tool now supports `--ignore-formatted`, which skips log directories that are already formatted instead of failing, so re-running on every container start is a no-op. This also stops the grep from masking genuine format failures whose message happens to contain that phrase.

### New `IS_DYNAMIC_QUORUM` environment variable

Optional boolean, defaults to `false`. When true, `--no-initial-controllers` is passed to `kafka-storage format`, so the node joins the existing controller quorum rather than writing its own initial voter set.

- Parsing is case-insensitive (`true` / `True` / `TRUE`).
- Unset or empty is treated as `false`.
- Any other value fails fast at startup with a clear message, rather than being silently treated as false. A typo like `IS_DYNAMIC_QUORUM=yes` would otherwise format with an initial voter set and leave the operator debugging a node that cannot join the quorum.

## Documentation

Each image's README gains an `IS_DYNAMIC_QUORUM` section stating that it must **only** be set to `true` after the cluster has completed migration to a dynamic controller quorum (KIP-853). Until that migration is complete the quorum membership is still static (`controller.quorum.voters`), and formatting without an initial controller set produces a node that cannot join the quorum.

Note that the authoritative customer-facing [Configuration Reference](https://docs.confluent.io/platform/current/installation/docker/config-reference.html) lives in a separate repo and will need the same entry for customers to find this.

## Test plan

- [x] `bash -n` on all three `ensure` scripts.
- [x] Verified the branching by exercising the extracted logic against a `kafka-storage` stub: unset, empty, `true`, `True`, `TRUE`, and `false` all produce the expected argument list; an invalid value exits 1.
- [ ] Image integration tests (`kafka/test/`) — these spin up real Docker clusters and have no coverage of the format path; not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)