### PR TITLE
[DO NOT MERGE]Point PACKAGES_URL at custom build CB-1021 (minimal diff)

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -43,7 +43,7 @@ global_job_config:
       - export CONFLUENT_VERSION=$(pinto get-version --build $BUILD_KEY --key confluent.version)
       - export DEFAULT_OS_TYPE="ubi"
       - export URL_CONFLUENT_VERSION=$(echo $CONFLUENT_VERSION | awk -F . '{print $1"."$2}')
-      - export PACKAGES_URL="https://s3-us-west-2.amazonaws.com/dev-confluent-packages-654654529379-us-west-2/$BRANCH_TAG/$LATEST_PACKAGING_BUILD_NUMBER/PACKAGE_TYPE/$URL_CONFLUENT_VERSION"
+      - export PACKAGES_URL="https://s3-us-west-2.amazonaws.com/dev-confluent-packages-654654529379-us-west-2/custom-build/CB-1021/PACKAGE_TYPE/8.4"
       - export PACKAGING_BUILD_NUMBER=$LATEST_PACKAGING_BUILD_NUMBER
       - >-
         if [[ $IS_BETA || $IS_HOTFIX || $IS_POST ]]; then


### PR DESCRIPTION
Testing the minimal one-line PACKAGES_URL override pattern (per ksql-images#278), leaving CONFLUENT_VERSION/PACKAGING_BUILD_NUMBER's pinto/S3 dynamic lookups untouched, instead of hardcoding all three as in #511.