### PR TITLE
KMETA-3163: Add IS_DYNAMIC_QUORUM env var to control --no-initial-controllers (backport to 8.0.x)

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -7,6 +7,12 @@ Docker image for deploying and running the Community Version of Kafka packaged w
 * [Notes on using the image](https://docs.confluent.io/platform/current/installation/docker/installation.html) 
 * [Configuration Reference](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#confluent-ak-configuration)
 
+### `IS_DYNAMIC_QUORUM`
+
+Optional boolean (`true` or `false`, defaults to `false`) that controls how the image formats the storage directory at container start. When set to `true`, the image passes `--no-initial-controllers` to `kafka-storage format`, so the node joins the existing controller quorum instead of writing its own initial voter set.
+
+**Only set `IS_DYNAMIC_QUORUM=true` after the cluster has completed migration to a dynamic controller quorum ([KIP-853](https://cwiki.apache.org/confluence/display/KAFKA/KIP-853%3A+KRaft+Controller+Membership+Changes)).** Until that migration is complete the quorum membership is still static (`controller.quorum.voters`), and formatting without an initial controller set produces a node that cannot join the quorum. Leave the variable unset or `false` on clusters that have not migrated.
+
 ## Resources
 
 * [Docker Quick Start for Apache Kafka using Confluent Platform](https://docs.confluent.io/platform/current/quickstart/ce-docker-quickstart.html#ce-docker-quickstart)

--- a/kafka/include/etc/confluent/docker/ensure
+++ b/kafka/include/etc/confluent/docker/ensure
@@ -23,7 +23,24 @@ dub path "$KAFKA_DATA_DIRS" writable
 # Required step: Format the storage directory with provided cluster ID unless it already exists.
 echo "===> Using provided cluster id $CLUSTER_ID ..."
 
-# A bit of a hack to not error out if the storage is already formatted.  Need storage-tool to support this
-result=$(kafka-storage format --cluster-id=$CLUSTER_ID -c /etc/kafka/kafka.properties 2>&1) || \
-    echo $result | grep -i "already formatted" || \
-    { echo $result && (exit 1) }
+# --ignore-formatted skips log directories that are already formatted instead of failing, so this is
+# safe to re-run on every start.
+format_args=(--cluster-id="$CLUSTER_ID" -c /etc/kafka/kafka.properties --ignore-formatted)
+
+# IS_DYNAMIC_QUORUM tells the storage tool that this cluster's controller quorum membership is
+# managed dynamically (KIP-853) rather than by a static controller.quorum.voters list.  Only set it
+# to true AFTER the cluster has completed the migration to a dynamic quorum; setting it on a cluster
+# that still uses a static voter set will format a node that cannot join the quorum.
+case "${IS_DYNAMIC_QUORUM:-false}" in
+    [Tt][Rr][Uu][Ee])
+        echo "===> IS_DYNAMIC_QUORUM is true, formatting without an initial controller set ..."
+        format_args+=(--no-initial-controllers)
+        ;;
+    [Ff][Aa][Ll][Ss][Ee]) ;;
+    *)
+        echo "IS_DYNAMIC_QUORUM must be true or false, got '$IS_DYNAMIC_QUORUM'"
+        exit 1
+        ;;
+esac
+
+kafka-storage format "${format_args[@]}"

--- a/local/README.md
+++ b/local/README.md
@@ -9,6 +9,12 @@ Confluent-Local image deploys Apache Kafka along with Confluent Community RestPr
 ## Using the image
 This Docker image starts with KRaft as the default mode. Check [here](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#confluent-enterprise-ak-configuration) to modify the default configurations. 
 
+### `IS_DYNAMIC_QUORUM`
+
+Optional boolean (`true` or `false`, defaults to `false`) that controls how the image formats the storage directory at container start. When set to `true`, the image passes `--no-initial-controllers` to `kafka-storage format`, so the node joins the existing controller quorum instead of writing its own initial voter set.
+
+**Only set `IS_DYNAMIC_QUORUM=true` after the cluster has completed migration to a dynamic controller quorum ([KIP-853](https://cwiki.apache.org/confluence/display/KAFKA/KIP-853%3A+KRaft+Controller+Membership+Changes)).** Until that migration is complete the quorum membership is still static (`controller.quorum.voters`), and formatting without an initial controller set produces a node that cannot join the quorum. Leave the variable unset or `false` on clusters that have not migrated.
+
 ## Resources
 
 [What is Apache Kafka?](https://developer.confluent.io/learn-kafka)

--- a/local/include/etc/confluent/docker/ensure
+++ b/local/include/etc/confluent/docker/ensure
@@ -25,8 +25,25 @@ if [[ -n "${KAFKA_PROCESS_ROLES-}" ]]
 then
     echo "===> Using provided cluster id $CLUSTER_ID ..."
 
-    # A bit of a hack to not error out if the storage is already formatted.  Need storage-tool to support this
-    result=$(kafka-storage format --cluster-id=$CLUSTER_ID -c /etc/kafka/kafka.properties 2>&1) || \
-        echo $result | grep -i "already formatted" || \
-        { echo $result && (exit 1) }
+    # --ignore-formatted skips log directories that are already formatted instead of failing, so this is
+    # safe to re-run on every start.
+    format_args=(--cluster-id="$CLUSTER_ID" -c /etc/kafka/kafka.properties --ignore-formatted)
+
+    # IS_DYNAMIC_QUORUM tells the storage tool that this cluster's controller quorum membership is
+    # managed dynamically (KIP-853) rather than by a static controller.quorum.voters list.  Only set
+    # it to true AFTER the cluster has completed the migration to a dynamic quorum; setting it on a
+    # cluster that still uses a static voter set will format a node that cannot join the quorum.
+    case "${IS_DYNAMIC_QUORUM:-false}" in
+        [Tt][Rr][Uu][Ee])
+            echo "===> IS_DYNAMIC_QUORUM is true, formatting without an initial controller set ..."
+            format_args+=(--no-initial-controllers)
+            ;;
+        [Ff][Aa][Ll][Ss][Ee]) ;;
+        *)
+            echo "IS_DYNAMIC_QUORUM must be true or false, got '$IS_DYNAMIC_QUORUM'"
+            exit 1
+            ;;
+    esac
+
+    kafka-storage format "${format_args[@]}"
 fi

--- a/server/README.md
+++ b/server/README.md
@@ -18,6 +18,12 @@ Confluent Server is a commercial component of Confluent Platform.
 * [Notes on using the image](https://docs.confluent.io/platform/current/installation/docker/installation.html) 
 * [Configuration Reference](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#confluent-enterprise-ak-configuration)
 
+### `IS_DYNAMIC_QUORUM`
+
+Optional boolean (`true` or `false`, defaults to `false`) that controls how the image formats the storage directory at container start. When set to `true`, the image passes `--no-initial-controllers` to `kafka-storage format`, so the node joins the existing controller quorum instead of writing its own initial voter set.
+
+**Only set `IS_DYNAMIC_QUORUM=true` after the cluster has completed migration to a dynamic controller quorum ([KIP-853](https://cwiki.apache.org/confluence/display/KAFKA/KIP-853%3A+KRaft+Controller+Membership+Changes)).** Until that migration is complete the quorum membership is still static (`controller.quorum.voters`), and formatting without an initial controller set produces a node that cannot join the quorum. Leave the variable unset or `false` on clusters that have not migrated.
+
 ## Resources
 
 * [Docker Quick Start for Apache Kafka using Confluent Platform](https://docs.confluent.io/platform/current/quickstart/ce-docker-quickstart.html#ce-docker-quickstart)

--- a/server/include/etc/confluent/docker/ensure
+++ b/server/include/etc/confluent/docker/ensure
@@ -23,7 +23,24 @@ dub path "$KAFKA_DATA_DIRS" writable
 # Required step: Format the storage directory with provided cluster ID unless it already exists.
 echo "===> Using provided cluster id $CLUSTER_ID ..."
 
-# A bit of a hack to not error out if the storage is already formatted.  Need storage-tool to support this
-result=$(kafka-storage format --cluster-id=$CLUSTER_ID -c /etc/kafka/kafka.properties 2>&1) || \
-    echo $result | grep -i "already formatted" || \
-    { echo $result && (exit 1) }
+# --ignore-formatted skips log directories that are already formatted instead of failing, so this is
+# safe to re-run on every start.
+format_args=(--cluster-id="$CLUSTER_ID" -c /etc/kafka/kafka.properties --ignore-formatted)
+
+# IS_DYNAMIC_QUORUM tells the storage tool that this cluster's controller quorum membership is
+# managed dynamically (KIP-853) rather than by a static controller.quorum.voters list.  Only set it
+# to true AFTER the cluster has completed the migration to a dynamic quorum; setting it on a cluster
+# that still uses a static voter set will format a node that cannot join the quorum.
+case "${IS_DYNAMIC_QUORUM:-false}" in
+    [Tt][Rr][Uu][Ee])
+        echo "===> IS_DYNAMIC_QUORUM is true, formatting without an initial controller set ..."
+        format_args+=(--no-initial-controllers)
+        ;;
+    [Ff][Aa][Ll][Ss][Ee]) ;;
+    *)
+        echo "IS_DYNAMIC_QUORUM must be true or false, got '$IS_DYNAMIC_QUORUM'"
+        exit 1
+        ;;
+esac
+
+kafka-storage format "${format_args[@]}"


### PR DESCRIPTION
Backport of #506 to the `8.0.x` release branch.

Cherry-picks commit `0b5b620f52e55f84ca94af77190ea3a5c4515f7d` ("Add IS_DYNAMIC_QUORUM env var to control `--no-initial-controllers`") from `master` via `git cherry-pick -x`.

### Summary
Reworks the `kafka-storage format` invocation in the cp-kafka, cp-server, and confluent-local `ensure` scripts:

- Replaces the "grep for already formatted" hack with `--ignore-formatted`, so a re-run is a no-op instead of a swallowed error. This also stops masking genuine format failures.
- Adds an `IS_DYNAMIC_QUORUM` boolean env var. When `true`, `--no-initial-controllers` is passed to `format` so the node joins the existing controller quorum rather than writing its own initial voter set. Parsing is case-insensitive, defaults to `false`, and rejects unrecognized values so a typo fails loudly at startup.
- Documents `IS_DYNAMIC_QUORUM` in each image's README, including the warning that it must only be set to `true` after the cluster has completed migration to a dynamic controller quorum ([KIP-853](https://cwiki.apache.org/confluence/display/KAFKA/KIP-853%3A+KRaft+Controller+Membership+Changes)).

### Backport notes
- On `8.0.x` the cp-kafka and cp-server `ensure` scripts use `dub path ...` where newer branches use `ub path ...`. That line sits outside the cherry-picked hunk, so the 3-way merge applied cleanly and **preserved `dub`** while adding the new format logic. No manual conflict resolution was needed.
- The commit retains the `(cherry picked from commit 0b5b620f52e55f84ca94af77190ea3a5c4515f7d)` trailer for traceability.
