### PR TITLE
CPBR-4102 POC: remove s390x_docker_repos from service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -91,9 +91,6 @@ semaphore:
           options:
             - 'True'
             - 'False'    
-cp_dockerfile:
-  s390x_docker_repos: ['confluentinc/cp-server', 'confluentinc/cp-server-connect']
-  s390x_maven_modules: ['server', 'server-connect']
 code_artifact:
   enable: true
   package_paths:


### PR DESCRIPTION
## Summary
- Removes `cp_dockerfile.s390x_docker_repos` / `s390x_maven_modules` from `service.yml` on master
- POC step for CPBR-4102 ("remove s390x promote step from docker images repo") -- observing what ServiceBot actually regenerates once this is removed, before deciding on a finer-grained promote-only-disable approach
- This is a full removal (both s390x build and s390x-to-DockerHub promote stop), not a promote-only split

## Why
Real decision (FINAL design doc + 2026-09-04 Slack thread with Prince/Mihir): s390x moves to ICR-only, Docker Hub promotion stops, targeting CP 8.4.0/master ahead of the branch cut. This PR is the first observable step to confirm ServiceBot's regeneration behavior on master before further changes.

## Test plan
- [ ] Merge and confirm ServiceBot's nightly run (or a manual trigger) regenerates `.semaphore/cp_dockerfile_build.yml` and `.semaphore/cp_dockerfile_promote.yml` with the s390x blocks removed
- [ ] Confirm no other s390x references remain that would break